### PR TITLE
Ggaliens/planecut changes 419

### DIFF
--- a/plugins_src/commands/wpc_plane_cut.erl
+++ b/plugins_src/commands/wpc_plane_cut.erl
@@ -14,7 +14,7 @@
 %%
 
 -module(wpc_plane_cut).
--export([init/0,menu/2,command/2]).
+-export([init/0,menu/2,command/2, plane_cut/3]).
 -include("wings.hrl").
 
 
@@ -725,7 +725,7 @@ loop_cut(Axis, Point, St0) ->
         AdjFaces = wings_face:from_edges(Edges, We0),
         case loop_cut_partition(AdjFaces, Edges, We0, []) of
           [_] ->
-            wings_u:error_msg(?__(2,"Edge loop doesn't divide mesh into two or more parts."));
+            {Sel0,St1}; 
           [_|Parts0] ->
             Parts = [gb_sets:to_list(P) || P <- Parts0],
             FirstComplement = ordsets:union(Parts),


### PR DESCRIPTION
OK ... comment removed.  Looked again at the behavior of the plane cut before and after change. 
Have a YOUTUBE video that might provide you some insights as to what is being changed , facilitated.

It has everything to do with what happens when a user sets up his/her cutting plan parallel to another face in the scene.  So perhaps an OUTLYING issue ... or perhaps not, if you are using my additional plug-ins to basically STRESS-TEST the existing plane-cut ... and at same time ... provide interesting new functionality. Anyway ... this is mostly just a export change for a very useful core function.

If anyone should have trouble with plane-cut a-la   one-off with Optigon modal style ... I will get t bottom of it and or revert using the FORCES of GIT you have shown me. I will do that proactive paranoid snap-shot testing as well ... once you get to the pull-request in due course of time. 
