### PR TITLE
Option to enable/disable texture filtering

### DIFF
--- a/src/wings_image.erl
+++ b/src/wings_image.erl
@@ -540,15 +540,19 @@ init_texture(Image0, TxId) ->
             gl:pushAttrib(?GL_TEXTURE_BIT),
             gl:enable(?GL_TEXTURE_2D),
             gl:bindTexture(?GL_TEXTURE_2D, TxId),
+            Ft=case wings_pref:get_value(filter_texture, false) of
+				true -> ?GL_LINEAR;
+				false -> ?GL_NEAREST
+            end,
             case wings_gl:is_ext({1,4},'GL_SGIS_generate_mipmap') of
               true ->
-                gl:texParameteri(?GL_TEXTURE_2D, ?GL_GENERATE_MIPMAP, ?GL_TRUE),
+              	gl:texParameteri(?GL_TEXTURE_2D, ?GL_GENERATE_MIPMAP, ?GL_TRUE),
                 gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MIN_FILTER,
                                  ?GL_LINEAR_MIPMAP_LINEAR);
               false ->
-                gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MIN_FILTER, ?GL_LINEAR)
+                gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MIN_FILTER, Ft)
             end,
-            gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MAG_FILTER, ?GL_LINEAR),
+            gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MAG_FILTER, Ft),
             gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_S, ?GL_REPEAT),
             gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_T, ?GL_REPEAT),
             Format = texture_format(Image),

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -428,8 +428,12 @@ apply_texture_1(Image, TxId) ->
     gl:enable(?GL_TEXTURE_2D),
     gl:texEnvi(?GL_TEXTURE_ENV, ?GL_TEXTURE_ENV_MODE, ?GL_MODULATE),
     gl:bindTexture(?GL_TEXTURE_2D, TxId),
-    gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MAG_FILTER, ?GL_LINEAR),
-    gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MIN_FILTER, ?GL_LINEAR),
+	Ft=case wings_pref:get_value(filter_texture, false) of
+		true -> ?GL_LINEAR;
+		false -> ?GL_NEAREST
+	end,
+    gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MAG_FILTER, Ft),
+    gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_MIN_FILTER, Ft),
     gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_S, ?GL_REPEAT),
     gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_T, ?GL_REPEAT),    
     case wings_gl:is_ext({1,2}) of

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -53,7 +53,11 @@ menu(#st{views={CurrentView,Views}}=St) ->
        crossmark(show_materials)},
       {?__(46,"Show Textures"),show_textures,
        ?__(47,"Show textures"),
-       crossmark(show_textures)}]}},
+       crossmark(show_textures)},
+      separator,
+      {?__(74,"Filter Textures"),filter_texture,
+       ?__(75,"Activates Texture Filtering for all textures. (Disable filtering for accurate display of very low resolution textures)"),
+	   crossmark(filter_texture)}]}},
      separator,
      {?__(7,"Wireframe"),wireframe,?__(8,"Display selected objects as a wireframe (same for all objects if nothing is selected)")},
      {?__(9,"Shade"),shade,?__(10,"Display selected objects as shaded (same for all objects if nothing is selected)")},
@@ -294,6 +298,15 @@ command(orthogonal_view, St) ->
     St;
 command({show,show_textures}, St) ->
     toggle_option(show_textures),
+    wings_dl:map(fun(#dlo{proxy_data=PD}=D, _) ->
+			 %% Must invalidate vertex buffers.
+			 D#dlo{work=none,smooth=none,vab=none,
+			       proxy_data=wings_proxy:invalidate(PD, vab)};
+		    (D, _) -> D
+		 end, []),
+    St;
+command({show,filter_texture}, St) ->
+    toggle_option(filter_texture),
     wings_dl:map(fun(#dlo{proxy_data=PD}=D, _) ->
 			 %% Must invalidate vertex buffers.
 			 D#dlo{work=none,smooth=none,vab=none,
@@ -857,6 +870,7 @@ init() ->
     wings_pref:set_default(show_colors, true),
     wings_pref:set_default(show_materials, true),
     wings_pref:set_default(show_textures, true),
+	wings_pref:set_default(filter_texture, true),
     wings_pref:set_default(frame_disregards_mirror, false),
     wings_pref:set_default(scene_lights, false).
 


### PR DESCRIPTION
The changes i did to the files wings_image.erl,wings_material.erl and wings_view.erl make possible to enable/disable texture filtering.

It was added a menu option under Main menu->Show: 'Filter Texture', because is impossible to add a RMB event to a plan menu (in accord with the comments in the wings_menu.erl file):
%%%   The Help field is normalized to
%%%      String       for plain (pull-down) menus
%%%      {L,M,R}      for pop-up menus

It was proposed on Wings3d ODF: http://nendowingsmirai.yuku.com/topic/7504/Adding-option-to-enable-disable-texture-filtering-W-I-P
