### PR TITLE
New options for Selection and Rename operations

### DIFF
--- a/src/wings_shape.erl
+++ b/src/wings_shape.erl
@@ -269,7 +269,7 @@ event({set_knob_pos,Pos}, #ost{first=First0,n=N}=Ost0) ->
 	    get_event(Ost);
 	_ -> keep
     end;
-event({action,Action}, #ost{st=St0}=Ost) ->
+event({action,Action}, #ost{st=#st{sel=Sel}=St0}=Ost) ->
     case Action of
       {objects,{remove_from_folder,Id}} ->
           St = move_to_folder(?NO_FLD, [Id], St0),
@@ -287,6 +287,17 @@ event({action,Action}, #ost{st=St0}=Ost) ->
           St = delete_folder(Folder, St0),
           send_client({new_state,St}),
           get_event(Ost);
+      {objects,{rename_objects,normal}} ->
+		Ids=wings_sel:fold(
+			fun(_,#we{id=Id},Acc) ->
+				Acc++[Id]
+			end, [], St0),
+		if Ids=/=[] -> command({rename_objects,Ids},Ost);
+			true -> get_event(Ost)
+		end;
+      {objects,{rename_objects,masked}} ->
+          rename_filtered_dialog(length(Sel)>1),
+          get_event(Ost);
       {objects,Cmd} ->
           command(Cmd, Ost);
       {create_folder,[Folder]} ->
@@ -295,6 +306,14 @@ event({action,Action}, #ost{st=St0}=Ost) ->
           get_event(Ost);
       {rename_folder,[OldName,NewName]} ->
           St = rename_folder(OldName, NewName, St0),
+          send_client({update_state,St}),
+          get_event(Ost);
+      {rename_selected_objects,[Mask]} ->
+          St=wings_body:rename_selected(Mask,St0),
+          send_client({update_state,St}),
+          get_event(Ost);
+      {rename_filtered_objects,[Filter,Mask]} ->
+          St=wings_body:rename_filtered(Filter,Mask,St0),
           send_client({update_state,St}),
           get_event(Ost)
     end;
@@ -343,6 +362,8 @@ command({duplicate_object,Id}, _) ->
     send_client({action,{body,{duplicate_object,[Id]}}});
 command({rename_object,Id}, _) ->
     send_client({action,{body,{rename,[Id]}}});
+command({rename_objects,Ids}, _) ->
+    send_client({action,{body,{rename,Ids}}});
 command(create_folder, _) ->
     create_folder_dialog();
 command({rename_folder,OldName}, _) ->
@@ -761,8 +782,10 @@ do_menu(Act, X, Y, #ost{os=Objs}) ->
               ?STR(do_menu,2,"Duplicate selected objects")},
              {?STR(do_menu,3,"Delete"),menu_cmd(delete_object, Id),
               ?STR(do_menu,4,"Delete selected objects")},
-             {?STR(do_menu,5,"Rename"),menu_cmd(rename_object, Id),
-              ?STR(do_menu,6,"Rename selected objects")},
+             {?STR(do_menu,5,"Rename"),rename_menu(Id),
+              {?STR(do_menu,6,"Rename selected objects"),
+               ?STR(do_menu,14,"Rename all selected objects"),
+               ?STR(do_menu,15,"Rename objects using Search and Replace")},[]},
               separator,
              {?__(7,"Create Folder"),menu_cmd(create_folder)}]++RF;
         Folder ->
@@ -778,11 +801,27 @@ do_menu(Act, X, Y, #ost{os=Objs}) ->
     end,
     wings_menu:popup_menu(X, Y, objects, Menu).
 
+rename_menu(Id) ->
+    fun(1, _Ns) ->
+      button_menu_cmd(rename_object, Id);
+       (2, _Ns) ->
+      button_menu_cmd(rename_objects, normal);
+       (3, _Ns) ->
+      button_menu_cmd(rename_objects, masked);
+       (_, _) -> ignore
+    end.
+
 menu_cmd(Cmd) ->
     {'VALUE',Cmd}.
 
 menu_cmd(Cmd, Id) ->
     {'VALUE',{Cmd,Id}}.
+
+button_menu_cmd(Cmd) ->
+	{objects,{Cmd}}.
+
+button_menu_cmd(Cmd, Id) ->
+	{objects,{Cmd,Id}}.
 
 %%%
 %%% Draw the Geometry Graph window.
@@ -1791,6 +1830,45 @@ rename_folder_dialog(OldName) ->
            {text,OldName,[]}]}],
     wings_ask:dialog(true, ?__(2,"Rename Folder"), Qs,
            fun(Res) -> {rename_folder,[OldName|Res]} end).
+
+rename_filtered_dialog(ManyObjs) ->
+    ModeHook=fun(Event, Params) ->
+            case Event of
+            update ->
+                {Var,_,Val,Store}=Params,
+                {store,gb_trees:update(Var,Val,Store)};
+            is_minimized ->
+                false;
+            is_disabled ->
+                {Var,_,Store}=Params,
+                case Var of
+                rn_search ->
+                    gb_trees:get(rn_mode,Store)=:=0;
+                rn_mode ->
+                    ManyObjs=:=false;
+                _ ->
+                    false
+                end
+            end
+    end,
+    Qs = [{vframe,
+          [{hradio, [{?__(6,"Selected objects"),0},
+                     {?__(7,"Search"),1}], 1,
+                     [{key,rn_mode},{title, ?__(8,"Apply to")},{hook,ModeHook}]
+                     },
+           {hframe, [{label,?__(1,"Search")},
+                     {text,"",[{info,?__(4,"Matching objects to be renamed. *'s may be used as wildcards")},
+                               {key,rn_search},{hook,ModeHook}]}]},
+           {hframe, [{label,?__(2,"Choose Name")},
+                     {text,"",[{info,[?__(5,"New name. Use % to indicate numbered objects and %number% for the start counter")]},
+                               {key,rn_name}]}]}]}],
+    wings_ask:dialog(true, ?__(3,"Replace"), Qs,
+           fun([{rn_mode,Mode},{rn_search,Filter},{rn_name,Mask}]=_Res) ->
+                case Mode of
+                0 -> {rename_selected_objects,[Mask]};
+                1 -> {rename_filtered_objects,[Filter,Mask]}
+                end
+           end).
 
 merge_st({_,_}=Data, _) ->
     Data;

--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -25,6 +25,7 @@
 	 array_is_empty/1,array_entries/1,
 	 nice_float/1,
 	 unique_name/2,
+	 is_name_masked/2,
 	 lib_dir/1,
 	 tc/3,
 	 limit/2]).
@@ -236,6 +237,59 @@ limit(Val, {Min,Max}) when Min < Max, Val < Min -> Min;
 limit(Val, {Min,Max}) when Min < Max, Val > Max -> Max;
 limit(Val, {Min,Max}) when Min < Max -> Val.
 
+%%
+%% Check if name match with the mask.
+%%
+
+is_name_masked(Name,Mask) ->
+    Mask0=string:to_upper(Mask),
+    Name0=string:to_upper(Name),
+    is_name_masked_0(Name0,Mask0,get_mask_pos(Mask0)).
+
+is_name_masked_0(_Name,"*",_MaskPos) -> true;
+is_name_masked_0([],_Mask,_MaskPos) -> false;
+is_name_masked_0(_Name,[],_MaskPos) -> false;
+is_name_masked_0(Name,Name,[]) -> true;
+is_name_masked_0(_Name,_Mask,[]) -> false;
+is_name_masked_0(Name,Mask,[H|[]]=_MaskPos) ->  % *text with only one wildcard
+    Mlen=string:len(Mask),
+    case H of
+    1 ->     % *text value
+        Mask0=string:sub_string(Mask,H+1),
+        MPos=string:rstr(Name,Mask0),
+        (string:len(Name)-MPos+1)=:=(Mlen-1);
+    Mlen ->  % text value*
+        Mask0=string:sub_string(Mask,1,Mlen-1),
+        string:str(Name,Mask0)=:=1;
+    _ ->     % text *value
+        Mask0=string:sub_string(Mask,1,H-1),
+        Mask1=string:sub_string(Mask,H+1),
+        MPos=string:rstr(Name,Mask1),
+        Mlen0=string:len(Mask1),
+        (string:str(Name,Mask0)=:=1) and ((string:len(Name)-MPos)=:=(Mlen0-1))
+    end;
+is_name_masked_0(Name,Mask,[H|[H0|_T0]=_T]=_MaskPos) ->  % *text with more than one wildcard
+    case H of
+    1 ->     % *text value
+        Mask0=string:sub_string(Mask,H+1,H0-1),
+        Mask1=string:sub_string(Mask,H0),
+        case string:str(Name,Mask0) of
+        0 -> false;
+        NPos ->
+            Name0=string:sub_string(Name,NPos+H0-H-1),
+            is_name_masked_0(Name0,Mask1,get_mask_pos(Mask1))
+        end;
+    _ ->     % te*xt value*
+        Mask0=string:sub_string(Mask,1,H-1),
+        Mask1=string:sub_string(Mask,H),
+        case string:str(Name,Mask0) of
+        1 ->
+            Name0=string:sub_string(Name,H),
+            is_name_masked_0(Name0,Mask1,get_mask_pos(Mask1));
+        _ -> false
+        end
+    end.
+
 %%%
 %%% Local functions.
 %%%
@@ -276,6 +330,20 @@ lib_dir(wings) ->
     end;
 lib_dir(Lib) ->
     code:lib_dir(Lib).
+
+get_mask_pos([]) -> [];
+get_mask_pos(Mask) ->
+    get_mask_pos_1(Mask,0,[]).
+
+get_mask_pos_1([],_,Acc) -> Acc;
+get_mask_pos_1(Mask,Offset,Acc) ->
+    case string:str(Mask,"*") of
+    0 -> Acc;
+    Pos ->
+        Pos0=Pos+Offset,
+        get_mask_pos_1(string:sub_string(Mask,Pos+1),Pos0,Acc++[Pos0])
+    end.
+
 
 % % % % % % % % % % % % % % % % % % %
 %% Strings for Translating Hotkeys %%


### PR DESCRIPTION
NOTE: - Added Select|By|Name option in which selections using a matching name can be made by combining the "*" wildcard.
- Added new options for Renaming objects in the Geometry Graph window:
  LMB -> "Rename selected objects" (the current option)
  MMB -> "Rename all selected objects" (the option already enabled in Body mode)
  RMB -> "Rename objects filtered using a mask for name" (new option)

Now, Rename objects can be applied to several object at once, by using a selection or a search mask (like _box_). Also, the new name has a sequential number appended to it or placed in a defined position by using the "%" wildcard. It's possible to define the starter number by puting it between two "%" character (like: Cube%100%). [Micheus]
