### PR TITLE
Fix operator precedence when checking for modified module.

### DIFF
--- a/src/user_default.erl
+++ b/src/user_default.erl
@@ -261,7 +261,7 @@ module_modified(Path, PrevCompileTime, PrevSrc) ->
       CompileOpts =  binary_to_term(CB),
       CompileTime = proplists:get_value(time, CompileOpts),
       Src = proplists:get_value(source, CompileOpts),
-      not (CompileTime == PrevCompileTime) and (Src == PrevSrc)
+      not ((CompileTime == PrevCompileTime) and (Src == PrevSrc))
   end.
 
 find_module_file(Path) ->


### PR DESCRIPTION
Would previously not work when module path had changed, c.f.
(not A and B) is evaluated as ((not A) and B), and in this case
what we want is (not (A and B)).
