### PR TITLE
It was fixed three warnings present in the master branch:

### DIFF
--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -226,7 +226,7 @@ select_material_1(SelAct,Sel1,Sel2,Acc) ->
     end.
 
 %% select the elements (face/edge/vertice) using the Mat
-selected_we(SelMode,#we{id=Id,fs=Ftab,perm=Perm}=We, Mat) ->
+selected_we(SelMode,#we{id=Id,fs=Ftab}=We, Mat) ->
     MatFaces = wings_facemat:mat_faces(gb_trees:to_list(Ftab), We),
     case keyfind(Mat, 1, MatFaces) of
 	false ->

--- a/src/wings_shape.erl
+++ b/src/wings_shape.erl
@@ -830,9 +830,6 @@ menu_cmd(Cmd) ->
 menu_cmd(Cmd, Id) ->
     {'VALUE',{Cmd,Id}}.
 
-button_menu_cmd(Cmd) ->
-	{objects,{Cmd}}.
-
 button_menu_cmd(Cmd, Id) ->
 	{objects,{Cmd,Id}}.
 

--- a/src/wings_wm_toplevel.erl
+++ b/src/wings_wm_toplevel.erl
@@ -142,7 +142,7 @@ get_ctrl_event(Cs) ->
     {replace,fun(Ev) -> ctrl_event(Ev, Cs) end}.
 		     
 ctrl_event(redraw, Cs) ->
-%    ctrl_message(),
+    ctrl_message(),
     ctrl_redraw(Cs);
 ctrl_event(#mousebutton{button=1,state=?SDL_PRESSED},
 	   #ctrl{state=moving,prev_focus=Focus}=Cs) ->


### PR DESCRIPTION
1) wings_shape.erl:833: Warning: function button_menu_cmd/1 is unused (I realy defined it without be necessary)
2) wings_material.erl:229: Warning: variable 'Perm' is unused (Perm was "moved" to select_material/3 - I forgot to remove it in this header)
3) wings_wm_toplevel.erl:233: Warning: function ctrl_message/0 is unused (I forgot the line calling this function commented)
