### PR TITLE
Bug fixes for Wings3d pre 1.5 (Snapshot 2)

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -1067,7 +1067,7 @@ fake_sel_1(St0) ->
 
 add_faces(NewFs,St0=#st{bb=ASt=#uvstate{id=Id,mode=Mode,st=GeomSt=#st{shapes=Shs0}}}) ->
     case {NewFs,Mode} of
-	{_,object} -> St0;
+	{_,object} -> wings_shape:show_all(St0);
 	{object,_} -> %% Force a chart rebuild, we are switching object mode
 	    We = gb_trees:get(Id,Shs0),
 	    Shs = gb_trees:update(Id, We#we{fs=undefined,es=array:new()}, Shs0),

--- a/src/wings_ask.erl
+++ b/src/wings_ask.erl
@@ -864,7 +864,7 @@ maybe_resize_move({W,H0}=Size0) ->
 
 
 return_result(#s{call=EndFun,owner=Owner,fi=Fi,store=Sto,
-		 level=Level,grab_win=GrabWin}=S0) ->
+		 level=Level,grab_win=GrabWin,preview=P}=S0) ->
 	Res0 = collect_result(Fi, Sto),
 	Res = filter_result_final(Res0),
     ?DEBUG_DISPLAY(other, {return_result,Res}),
@@ -878,7 +878,7 @@ return_result(#s{call=EndFun,owner=Owner,fi=Fi,store=Sto,
 	{dialog,Qs,Fun} ->
 	    S = #s{w=W,h=H} = setup_dialog(Qs, Fun),
 	    maybe_resize_move({W,H}),
-	    get_event(S#s{level=Level,grab_win=GrabWin,owner=Owner});
+	    get_event(S#s{level=Level,grab_win=GrabWin,owner=Owner,preview=P});
 	{commit,#st{}=St0,#st{}=St}->
 	     wings_wm:send(Owner, {current_state,St0}),
 	     wings_wm:send_after_redraw(Owner, {new_state,St}),

--- a/src/wings_facemat.erl
+++ b/src/wings_facemat.erl
@@ -146,7 +146,7 @@ hide_faces(#we{mat=L0,fs=Ftab}=We) ->
 %%  in the list Faces.
 show_faces(_, #we{mat=M}=We) when is_atom(M) -> We;
 show_faces(Faces, #we{mat=L0}=We) ->
-    L = show_faces_1(Faces, L0, []),
+    L = show_faces_1(gb_sets:to_list(Faces), L0, []),
     We#we{mat=L}.
 
 %% renumber(MaterialMapping, FaceOldToNew) -> MaterialMapping.
@@ -236,7 +236,7 @@ mat_merge([], Fos, Acc) ->
     rev_compress(Acc, Fos);
 mat_merge(Fns, [], Acc) ->
     rev_compress(Acc, Fns).
-    
+
 make_tab(Fs, M) ->
     make_tab_1(Fs, M, []).
 
@@ -290,7 +290,7 @@ compress(L) when is_list(L) ->
 	[] -> L;
 	M -> M
     end.
-    
+
 same_mat([]) -> [];
 same_mat([{_,M}|T]) -> same_mat_1(T, M).
 


### PR DESCRIPTION
NOTE
- Unhide all objects in UV editor window was not working. Reported by Misty Wisty; [Micheus]
- User hotkeys have precedence over default values added to the list in the initialization time. On this case, default entries are removed. Reported by haroon [Micheus]
-  Unhide adjacent faces were crashing when object has other than default material applied to it; [Micheus]
- Fixed an issue related to dynamic dialogs and  preview dialog feature on wings_ask.erl; [Micheus]
