### PR TITLE
Fixed a Wing3d crash related to Area Light

### DIFF
--- a/src/wings_facemat.erl
+++ b/src/wings_facemat.erl
@@ -145,6 +145,9 @@ hide_faces(#we{mat=L0,fs=Ftab}=We) ->
 %%  Update the material name mapping in the We for all faces
 %%  in the list Faces.
 show_faces(_, #we{mat=M}=We) when is_atom(M) -> We;
+show_faces(Faces, #we{mat=L0}=We) when is_list(Faces) ->
+    L = show_faces_1(Faces, L0, []),
+    We#we{mat=L};
 show_faces(Faces, #we{mat=L0}=We) ->
     L = show_faces_1(gb_sets:to_list(Faces), L0, []),
     We#we{mat=L}.


### PR DESCRIPTION
Fixed a Wing3d crash related to Area Light - by trying to edit its property or saving the project Wings3d was crashing.

The bug was introduced when I tried to fix an issue related to unhiding adjacent faces with other material than default one (on mv/bugs1.5.pre1b - https://github.com/dgud/wings/commit/5ee5a9d89ab035fa2ed5a93412b55fb74ffbae5e)
