### PR TITLE
It was fixed an issue related to exporter routine.

### DIFF
--- a/plugins_src/import_export/wpc_hlines.erl
+++ b/plugins_src/import_export/wpc_hlines.erl
@@ -72,7 +72,7 @@ command(_, _) -> next.
 export(Arg, Op, _) when is_atom(Arg) ->
     wpa:dialog(Arg, ?__(1,"Cartoon edges Render Options"), dialog(),
         fun(Res) -> {file, {Op, {eps, Res}}} end);
-export(Arg, Op, St0) when is_list(Arg) ->
+export(Arg, Op, St) when is_list(Arg) ->
     set_pref(Arg),
     Camera_info = wpa:camera_info([aim, distance_to_aim,
         azimuth, elevation, tracking,
@@ -84,11 +84,6 @@ export(Arg, Op, St0) when is_list(Arg) ->
         {subdivisions, get_pref(subdivisions, ?DEF_SUBDIVISIONS)},
         {win_size, wings_wm:win_size()},
         {ortho_view, wings_wm:get_prop(orthogonal_view)}],
-
-    %% Freeze virtual mirrors.
-    Shapes0 = gb_trees:to_list(St0#st.shapes),
-    Shapes = [{Id, wpa:vm_freeze(We)} || {Id, We} <- Shapes0],
-    St = St0#st{shapes = gb_trees:from_orddict(Shapes)},
 
     case Op of
         export ->

--- a/plugins_src/import_export/wpc_yafray.erl
+++ b/plugins_src/import_export/wpc_yafray.erl
@@ -404,12 +404,12 @@ command_file(Op, Ask, _St) when is_atom(Ask) ->
 
 -record(camera_info, {pos,dir,up,fov}).
 
-do_export(Op, Props0, Attr0, St0) ->
+do_export(Op, Props0, Attr0, St) ->
     SubDiv = proplists:get_value(subdivisions, Attr0, ?DEF_SUBDIVISIONS),
     Props = [{subdivisions,SubDiv}|Props0],
     [{Pos,Dir,Up},Fov] = wpa:camera_info([pos_dir_up,fov]),
     CameraInfo = #camera_info{pos=Pos,dir=Dir,up=Up,fov=Fov},
-    Attr = [CameraInfo,{lights,wpa:lights(St0)}|Attr0],
+    Attr = [CameraInfo,{lights,wpa:lights(St)}|Attr0],
     ExportFun = 
 	fun (Filename, Contents) ->
 		case catch export(Attr, Filename, Contents) of
@@ -420,10 +420,6 @@ do_export(Op, Props0, Attr0, St0) ->
 			{error,?__(2,"Failed to export")}
 		end
 	end,
-    %% Freeze virtual mirrors.
-    Shapes0 = gb_trees:to_list(St0#st.shapes),
-    Shapes = [{Id,wpa:vm_freeze(We)} || {Id,We} <- Shapes0],
-    St = St0#st{shapes=gb_trees:from_orddict(Shapes)},
     wpa:Op(Props, ExportFun, St).
 
 props(render, Attr) ->

--- a/src/wings_export.erl
+++ b/src/wings_export.erl
@@ -19,8 +19,8 @@
 -include("e3d_image.hrl").
 -import(lists, [foldl/3,keydelete/3,reverse/1,last/1]).
 
-export(Exporter, Name, Ps, #st{shapes=Shs}=St0) ->
-    St = wings_view:freeze_mirror(St0),
+export(Exporter, Name, Ps, St0) ->
+	#st{shapes=Shs} = St = wings_view:freeze_mirror(St0),
     Objs = foldl(fun(W, A) ->
 			 export_1(W, Ps, A)
 		 end, [], gb_trees:values(Shs)),


### PR DESCRIPTION
It was not passing the "freezed" objects to the exporting routine of any plugin. Thanks to nemyax for report it. [Micheus]

Also, it was removed the wpa:freeze call in two exports: yafray and hlines - not needed anymore.
