### PR TITLE
Added option to enable the user define the grid plane size/amount.

### DIFF
--- a/src/wings.hrl
+++ b/src/wings.hrl
@@ -59,7 +59,7 @@
 
 -define(LINE_HEIGHT, (?CHAR_HEIGHT+2)).
 -define(GROUND_GRID_SIZE, 1).
--define(CAMERA_DIST, (8.0*?GROUND_GRID_SIZE)).
+-define(GROUND_GRID_AMOUNT, 10).
 -define(NORMAL_LINEWIDTH, 1.0).
 -define(DEGREE, 176).				%Degree character.
 
@@ -95,7 +95,6 @@
 -define(NORMAL_MAP_UNIT,  1).
 -define(ENV_MAP_UNIT,     2).
 -define(TANGENT_ATTR,     5).
-
 %%
 
 -define(SLOW(Cmd), begin wings_io:hourglass(), Cmd end).

--- a/src/wings_drag.erl
+++ b/src/wings_drag.erl
@@ -124,7 +124,7 @@ unit_scales(Units) ->
     case wings_pref:get_value(drag_custom) of
       false ->
         default_drag(Units);
-      true -> 
+      true ->
         custom_drag(Units)
     end.
 
@@ -521,7 +521,7 @@ handle_drag_event(#mousebutton{button=3,state=?SDL_RELEASED},
   #drag{rmb_timer=StartTime}=Drag) when StartTime =/= 0 ->
 %% When Rmb is released we subtract the StartTime (when the Rmb was pressed)
 %% from the Stop time (relased) and if the result is less than 500000 ms, then
-%% we cancel the drag. If not we continue the drag using the 
+%% we cancel the drag. If not we continue the drag using the
     Stop = now(),
     Time = timer:now_diff(Stop, StartTime),
     % io:format("Time ~p\n",[Time]),
@@ -771,7 +771,8 @@ make_move_1([], []) -> [].
 
 magnet_radius(_Sign, #drag{falloff=none}=Drag) -> Drag;
 magnet_radius(Sign, #drag{falloff=Falloff0}=Drag0) ->
-    case Falloff0+Sign*?GROUND_GRID_SIZE/10 of
+    GridAmount=wings_pref:get_value(ground_grid_amount),
+    case Falloff0+Sign*?GROUND_GRID_SIZE/float(GridAmount) of
 	Falloff when Falloff > 0 ->
 	    Drag = Drag0#drag{falloff=Falloff},
 	    parameter_update(new_falloff, Falloff, Drag);
@@ -853,7 +854,7 @@ mouse_range(#mousemotion{x=X0, y=Y0, state=Mask},
 			{{no_change,LastMove},Drag};
 
 		{XD0,YD0} ->
-	
+
 			CS = constraints_scale(Unit,Mod,UnitScales),
 			XD = CS*(XD0 + Xt0),
 			YD = CS*(YD0 + Yt0),

--- a/src/wings_pref.erl
+++ b/src/wings_pref.erl
@@ -367,6 +367,7 @@ defaults() ->
      {constrain_axes,true},
      {mini_axis,true},
      {force_show_along_grid,false},
+     {ground_grid_amount, ?GROUND_GRID_AMOUNT},
      {force_ortho_along_axis,false},
      {body_hilite,true},
      {auto_rotate_angle,1.0},

--- a/src/wings_pref_dlg.erl
+++ b/src/wings_pref_dlg.erl
@@ -135,14 +135,18 @@ gen_prefs() ->
 	      {color,?__(42,"-Z Color"),neg_z_color}]}]}],
    [{title,?__(43,"Axes")}]},
 
-  {hframe,
-	 [{label_column,
-	   [{color,?__(32,"Color"),grid_color}]},
-	    {?__(33,"Force Axis-Aligned Grid"),force_show_along_grid,
-	   [{info,?__(34,"Always show the grid when the view is aligned along one of the major axes")}]},
-	    {?__(aa_ortho1,"Force Axis-Aligned Ortho"),force_ortho_along_axis,
-	   [{info, ?__(aa_ortho2,"Always go into orthogonal mode when the view is aligned along one of the major axes")}]}],
-     [{title,?__(35,"Grid")}]}|multisampling()]}.
+   {hframe,
+     [{vframe,
+       [{hframe,
+         [{label_column, [{color,?__(32,"Color"),grid_color}]},
+          {?__(33,"Force Axis-Aligned Grid"),force_show_along_grid,
+            [{info,?__(34,"Always show the grid when the view is aligned along one of the major axes")}]},
+          {?__(aa_ortho1,"Force Axis-Aligned Ortho"),force_ortho_along_axis,
+            [{info, ?__(aa_ortho2,"Always go into orthogonal mode when the view is aligned along one of the major axes")}]}]},
+        {hframe,
+         [{label,?__(73,"Grid size")},
+          {slider,{text,ground_grid_amount,[{info, ?__(74,"Defines the grid size in Wings3d unit")},{range,{10,200}}]}}]}]
+   }],[{title,?__(35,"Grid")}]}|multisampling()]}.
      
 multisampling() ->
     case wings_pref:get_value(multisample) of

--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -371,7 +371,7 @@ draw_vertices(#dlo{src_we=#we{perm=P},vs=VsDlist}, vertex) when ?IS_SELECTABLE(P
     wings_dl:call(VsDlist);
 draw_vertices(_, _) -> ok.
 
-draw_hilite(#dlo{hilite=DL}) -> 
+draw_hilite(#dlo{hilite=DL}) ->
     wings_dl:call(DL).
 
 draw_orig_sel(#dlo{orig_sel=none}) -> ok;
@@ -408,7 +408,7 @@ draw_hard_edges(#dlo{hard=Hard}, SelMode) ->
     gl:lineWidth(hard_edge_width(SelMode)),
     gl:color3fv(wings_pref:get_value(hard_edge_color)),
     wings_dl:call(Hard).
-	
+
 draw_normals(#dlo{normals=none}) -> ok;
 draw_normals(#dlo{normals=Ns}) ->
     gl:color3f(0, 0, 1),
@@ -428,7 +428,9 @@ ground_and_axes() ->
     Axes = wings_wm:get_prop(show_axes),
     groundplane(Axes),
     case wings_pref:get_value(constrain_axes) of
-	true -> Yon = ?GROUND_GRID_SIZE * 10.0;
+	true ->
+		GridAmount=wings_pref:get_value(ground_grid_amount),
+		Yon = ?GROUND_GRID_SIZE * float(GridAmount);
 	false -> #view{yon=Yon} = wings_view:current()
     end,
     case Axes of
@@ -503,7 +505,9 @@ axis_letters() ->
 	    gl:loadIdentity(),
 
 	    case wings_pref:get_value(constrain_axes) of
-		true -> Yon = ?GROUND_GRID_SIZE * 11.0;
+		true ->
+			GridAmount=wings_pref:get_value(ground_grid_amount),
+			Yon = ?GROUND_GRID_SIZE * (float(GridAmount) +1.0);
 		false -> #view{yon=Yon} = wings_view:current()
 	    end,
 	    axis_letter_1(1, Yon, axisx, x_color, Info),
@@ -595,7 +599,8 @@ groundplane_1(Axes) ->
 	_ -> gl:rotatef(90, 1, 0, 0)
     end,
     gl:'begin'(?GL_LINES),
-    Sz = ?GROUND_GRID_SIZE * 10,
+	GridAmount=wings_pref:get_value(ground_grid_amount),
+    Sz = ?GROUND_GRID_SIZE * GridAmount,
     groundplane_2(-Sz, Sz, Sz, Axes),
     gl:'end'(),
     gl:popMatrix(),
@@ -681,7 +686,7 @@ enable_lighting(SceneLights) ->
 	    %% We put it here and not in apply_material, because we
 	    %% can't use some optimizations (e.g. reuse display lists)
 	    %% when drawing selected objects.
-	    gl:color4ub(255, 255, 255, 255), 
+	    gl:color4ub(255, 255, 255, 255),
 	    gl:useProgram(Prog)
     end.
 
@@ -693,7 +698,7 @@ disable_lighting() ->
     end.
 
 mini_axis_icon() ->
-    case wings_pref:get_value(mini_axis) of 
+    case wings_pref:get_value(mini_axis) of
     false -> ok;
     true ->
       gl:pushAttrib(?GL_ALL_ATTRIB_BITS),

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -301,7 +301,7 @@ command(orthogonal_view, St) ->
     St;
 command({show,What}, St) ->
     Prev = toggle_option(What),
-    if 
+    if
 	What =:= show_normals ->
 	    Prev andalso wings_dl:map(fun(D, _) -> D#dlo{normals=none} end, []);
 	What =:= show_materials; What =:= filter_texture ->
@@ -885,16 +885,18 @@ reset() ->
     reset(current()).
 
 reset(View) ->
+    Distance=wings_pref:get_value(ground_grid_amount)*0.5, %  80% of the grid size
     set_current(View#view{origin={0.0,0.0,0.0},
 			  azimuth=-45.0,elevation=25.0,
-			  distance=?CAMERA_DIST,
+			  distance=max(Distance,8.0),
 			  pan_x=0.0,pan_y=0.0,
 			  along_axis=none}).
 
 default_view() ->
+    Distance=wings_pref:get_value(ground_grid_amount)*0.5, %  80% of the grid size
     #view{origin={0.0,0.0,0.0},
 	  azimuth=-45.0,elevation=25.0,
-	  distance=?CAMERA_DIST,
+	  distance=max(Distance,8.0),
 	  pan_x=0.0,pan_y=0.0,
 	  along_axis=none,
 	  fov=45.0,
@@ -1054,7 +1056,7 @@ frame(St0) ->
     St = case wings_pref:get_value(frame_disregards_mirror) of
 	true ->
       kill_mirror(St0);
-	false -> 
+	false ->
 	  St0
 	end,
     frame_1(wings_sel:bounding_box(St)).


### PR DESCRIPTION
NOTE: It was add a new option to the Preferences dialog where the user can define the grid size/amount. [Micheus]
The range is 10 (current) to 200 and the camera distance (for reset camera operation) is calculated to 80% of this size (like the current too).
- ref. this thread  (with screen shot): http://www.wings3d.com/forum/showthread.php?tid=552&pid=3886#pid3886
