### PR TITLE
Bug fixes for 1.5.2

### DIFF
--- a/plugins_src/commands/wpc_sculpt.erl
+++ b/plugins_src/commands/wpc_sculpt.erl
@@ -1092,12 +1092,15 @@ pump_edges([],_,_,_) -> ok;
 pump_edges([{Id1,Inf1,Id2,Inf2}|SegInf],Vtab,Col,Range) ->
     {R1,G1,B1}=color_gradient(Col,Range,Inf1),
     {R2,G2,B2}=color_gradient(Col,Range,Inf2),
-    V1=array:get(Id1, Vtab),
-    V2=array:get(Id2, Vtab),
-    gl:color3f(R1,G1,B1),
-    gl:vertex3fv(V1),
-    gl:color3f(R2,G2,B2),
-    gl:vertex3fv(V2),
+    case {array:get(Id1, Vtab),array:get(Id2, Vtab)} of
+        {undefined,_} -> ok;
+        {_,undefined} -> ok;
+        {V1,V2} ->
+            gl:color3f(R1,G1,B1),
+            gl:vertex3fv(V1),
+            gl:color3f(R2,G2,B2),
+            gl:vertex3fv(V2)
+    end,
     pump_edges(SegInf,Vtab,Col,Range).
 
 %% It'll will provide de vertices data for 'update_dlist' function

--- a/plugins_src/commands/wpc_sel_win.erl
+++ b/plugins_src/commands/wpc_sel_win.erl
@@ -89,6 +89,16 @@ get_event(Ost) ->
     {replace,fun(Ev) -> event(Ev, Ost) end}.
 
 event(redraw, Ost) ->
+    wings_io:ortho_setup(),
+    {W,H} = wings_wm:win_size(),
+    case wings_pref:get_value(bitmap_icons) of
+        false -> wings_io:border(0, 0, W-1, H-1, ?PANE_COLOR);
+        true ->
+          wings_io:blend(wings_pref:get_value(outliner_geograph_bg),
+            fun(Color) ->
+              wings_io:border(0, 0, W-1, H-1, Color)
+            end)
+    end,
     draw_objects(Ost),
     keep;
 event({action,{sel_groups,Cmd}}, Ost) ->
@@ -380,10 +390,7 @@ active_object(Y0, #ost{lh=Lh,first=First,n=N}) ->
     end.
 
 draw_objects(#ost{os=Objs0,first=First,lh=Lh,active=Active,tracking=Trk,n=N0}=Ost) ->
-    wings_io:ortho_setup(),
-    {W,H} = wings_wm:win_size(),
-    wings_io:border(0, 0, W-1, H-1, ?PANE_COLOR),
-
+    {W,_H} = wings_wm:win_size(),
     Objs = lists:nthtail(First, Objs0),
     Lines = lines(Ost),
     N = case N0-First of

--- a/plugins_src/commands/wpc_views_win.erl
+++ b/plugins_src/commands/wpc_views_win.erl
@@ -85,6 +85,16 @@ get_event(Ost) ->
     {replace,fun(Ev) -> event(Ev, Ost) end}.
 
 event(redraw, Ost) ->
+    wings_io:ortho_setup(),
+    {W,H} = wings_wm:win_size(),
+    case wings_pref:get_value(bitmap_icons) of
+        false -> wings_io:border(0, 0, W-1, H-1, ?PANE_COLOR);
+        true ->
+          wings_io:blend(wings_pref:get_value(outliner_geograph_bg),
+            fun(Color) ->
+              wings_io:border(0, 0, W-1, H-1, Color)
+            end)
+    end,
     draw_objects(Ost),
     keep;
 event({action,{saved_views,Cmd}}, #ost{st=#st{views={_,Views0}}=St0}=Ost) ->
@@ -300,10 +310,7 @@ active_object(Y0, #ost{lh=Lh,first=First,n=N}) ->
     end.
 
 draw_objects(#ost{os=Objs0,first=First,lh=Lh,active=Active,tracking=Trk,n=N0}=Ost) ->
-    wings_io:ortho_setup(),
-    {W,H} = wings_wm:win_size(),
-    wings_io:border(0, 0, W-1, H-1, ?PANE_COLOR),
-
+    {W,_H} = wings_wm:win_size(),
     Objs = lists:nthtail(First, Objs0),
     Lines = lines(Ost),
     N = case N0-First of

--- a/src/wings_shape.erl
+++ b/src/wings_shape.erl
@@ -781,7 +781,7 @@ toggle_wire_folder(#we{id=Id0,pst=WePst}, #ost{st=#st{pst=Pst0}=St}) ->
 do_menu(-1, X, Y, _) ->
     Menu =
         [{?__(7,"Create Folder"),menu_cmd(create_folder)},
-         {?__(15,"Remove Selected From Folders"),
+         {?__(16,"Remove Selected From Folders"),
              menu_cmd(move_to_folder, ?NO_FLD)}],
     wings_menu:popup_menu(X, Y, objects, Menu);
 do_menu(Act, X, Y, #ost{os=Objs}) ->
@@ -789,7 +789,7 @@ do_menu(Act, X, Y, #ost{os=Objs}) ->
         {_,#we{id=Id,pst=Pst}} ->
             RF = case gb_trees:get(?FOLDERS, Pst) of
                 ?NO_FLD -> [];
-                _ -> [{?__(14,"Remove From Folder"),menu_cmd(remove_from_folder, Id)}]
+                _ -> [{?__(17,"Remove From Folder"),menu_cmd(remove_from_folder, Id)}]
             end,
             [{?STR(do_menu,1,"Duplicate"),menu_cmd(duplicate_object, Id),
               ?STR(do_menu,2,"Duplicate selected objects")},

--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -2917,12 +2917,15 @@ pump_edges([],_,_,_) -> ok;
 pump_edges([{Id1,Inf1,Id2,Inf2}|SegInf],Vtab,Col,Range) ->
     {R1,G1,B1}=color_gradient(Col,Range,Inf1),
     {R2,G2,B2}=color_gradient(Col,Range,Inf2),
-    V1=array:get(Id1, Vtab),
-    V2=array:get(Id2, Vtab),
-    gl:color3f(R1,G1,B1),
-    gl:vertex3fv(V1),
-    gl:color3f(R2,G2,B2),
-    gl:vertex3fv(V2),
+    case {array:get(Id1, Vtab),array:get(Id2, Vtab)} of
+        {undefined,_} -> ok;
+        {_,undefined} -> ok;
+        {V1,V2} ->
+            gl:color3f(R1,G1,B1),
+            gl:vertex3fv(V1),
+            gl:color3f(R2,G2,B2),
+            gl:vertex3fv(V2)
+    end,
     pump_edges(SegInf,Vtab,Col,Range).
 
 %% It'll will provide de vertices data for 'update_dlist' function

--- a/src/wings_u.erl
+++ b/src/wings_u.erl
@@ -169,7 +169,7 @@ pretty_filename(Name0) ->
     end.
 
 %% it returns a new file name using relative path
-%% Dst: it's the relative folder (used to be the project directory) 
+%% Dst: it's the relative folder (used to be the project directory)
 %% Src: file name (with full path) to be referenced
 %% it was implemented to be used in the exporters (see wpc_pov.erl)
 relative_path_name(Dst,Src) ->
@@ -178,7 +178,7 @@ relative_path_name(Dst,Src) ->
     Dir1=filename:split(get_dir(Src)),
 	case get_rel_path(Dir0,Dir1,[]) of
 		[] -> Fn;
-		Dir3 -> filename:join(Dir3,[Fn])
+		Dir3 -> filename:join(Dir3++[Fn])
 	end.
 
 get_dir(Dir) ->
@@ -257,7 +257,7 @@ log_file_dir({win32,_}) ->
 	  end,
     ok = win32reg:close(R),
     Res.
-	
+
 open_log_file(Name) ->
     {ok,F} = file:open(Name, [write]),
     {{Y,Mo,D},{H,Mi,_}} = erlang:localtime(),
@@ -307,7 +307,7 @@ dump_we(F, #we{name=Name,id=Id,es=Etab,fs=Ftab,
     io:format(F, "   next_id=~p\n", [Next]),
     dump_faces(F, gb_trees:to_list(Ftab)),
     dump_edges(F, array:sparse_to_orddict(Etab)).
-    
+
 dump_edges(F, Es) ->
     io:put_chars(F, "\n"),
     io:format(F, "Edge table\n", []),
@@ -323,7 +323,7 @@ dump_faces(F, Fs) ->
 
 %%
 %% Dumping of data structures.
-%% 
+%%
 
 show_edge(F, Edge, #edge{vs=Vs,ve=Ve,lf=Lf,rf=Rf,ltpr=Lpred,ltsu=Lsucc,
 			 rtpr=Rpred,rtsu=Rsucc}) ->


### PR DESCRIPTION
NOTE:
- Fixed an issue related to edges highlight in Tweak and Sculpt that was crashing wings when the object have hidden faces or holes. Thanks to Extrudeface for report it. [Micheus]
- Fixed a issue related to Select Group and Saved Camera windows not be drawn using the alpha settings as defined in the preferences. Thanks to Justanother1 for report it. [Micheus]
- Fixed the duplicated IDs in the language file for "Rename" operations available in the "Geometry Graph" window. Thanks to TulipVorlax. [Micheus]
- Fixed some inconsistencies in the file generated by the Collada plugin exporter. [Micheus]
- Fixed some issues related to images of materials exported by POV-Ray plugin. Thanks to RyMopar that reported it. [Micheus]
- It was also fixed an error in the "wings_u:relative_path_name" routine that was rebuilding the full path in a wrong way. [Micheus]
