### PR TITLE
It was added the possibility the user define more then diffuse color to default material.

### DIFF
--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -779,11 +779,12 @@ plugin_results(Name, Mat0, Res0) ->
 	    Mat = case true of
             Save ->
                 OpenGL=prop_get(opengl, Mat1, []),
-                wings_pref:set_value(material_default_full,OpenGL),
+                wings_pref:set_value(material_default_full, OpenGL),
                 Mat1;
             Restore ->
                 Dm = wings_pref:get_value(material_default),
-                OpenGL=make_opengl_mat(Dm, 1.0, [{vertex_colors,set}]),
+                {_,OpenGL0}=OpenGL=make_opengl_mat(Dm, 1.0, [{vertex_colors,set}]),
+                wings_pref:set_value(material_default_full, OpenGL0),
                 keyreplace(opengl, 1, Mat1, OpenGL);
             _ -> Mat1
 	    end,


### PR DESCRIPTION
NOTE:
- User now can define all OpenGL settings for "default" material.
  In the Material Editor dialog - after the user change those fields - a new button "Save" enable the user save them in the preferences. A button "Restore" enable the user to reset the default material to that usual Wings3d one that is hard coded.
- It was also changed a little the way how Wings3d read/import the "default" material from an existent file. If the only difference between both default materials is the OpenGL parameter, then the material being read is replaced by the current one, otherwise it create a new variation of that material name as already has been done. Thanks to MikeJ and oort for the suggestions and tests. [Micheus]
