### PR TITLE
Replaced the default Windows' Open dialog box for Font selection

### DIFF
--- a/plugins_src/mac_file/wp8_mac_file.erl
+++ b/plugins_src/mac_file/wp8_mac_file.erl
@@ -47,6 +47,8 @@ fileop_1({file,open_dialog,Prop,Cont}, _Next) ->
 	aborted -> keep;
 	Res -> Cont(Res)
     end;
+fileop_1({file,font_dialog,Prop,Cont}, Next) ->
+    fileop_1({file,open_dialog,Prop,Cont}, Next);  % foward the call to open dialog
 fileop_1({file,save_dialog,Prop,Cont}, _Next) ->
     Title = proplists:get_value(title, Prop, ?__(2,"Save")),
     Dir = proplists:get_value(directory, Prop),

--- a/plugins_src/primitives/wpc_tt.erl
+++ b/plugins_src/primitives/wpc_tt.erl
@@ -75,7 +75,7 @@ make_text(Ask, St) when is_atom(Ask) ->
               [{text,Text,[{key,{wpc_tt,text}}]},
                {slider,{text,Bisect,[{key,{wpc_tt,bisections}},{range, {0, 3}}]}},
                {button,{text,FontDirectory,[{key,{wpc_tt,fontdir}},
-                   {props,[{dialog_type,open_dialog},
+                   {props,[{dialog_type,font_dialog},
                    {extensions,[{".ttf",?__(3,"TrueType font")}]}]}]}}]},
             {vframe,[help_button()]}]}]}], St);
 

--- a/plugins_src/qt_file/wp8_qt_file.erl
+++ b/plugins_src/qt_file/wp8_qt_file.erl
@@ -56,6 +56,8 @@ fileop({message,Message}, _Next) ->
 fileop({file,open_dialog,Prop}, _Next) ->
     Title = proplists:get_value(title, Prop, "Open"),
     file_dialog(?OP_READ, Prop, Title);
+fileop({file,font_dialog,Prop}, Next) ->
+    fileop({file,open_dialog,Prop}, Next);  % foward the call to open dialog
 fileop({file,save_dialog,Prop}, _Next) ->
     Title = proplists:get_value(title, Prop, "Save"),
     file_dialog(?OP_WRITE, Prop, Title);

--- a/plugins_src/win32_file/wp8_file.erl
+++ b/plugins_src/win32_file/wp8_file.erl
@@ -22,6 +22,7 @@
 -define(OP_READ, 1).
 -define(OP_WRITE, 2).
 -define(OP_MAXIMIZE, 3).
+-define(OP_FONT, 4).
 
 menus() -> [].
 
@@ -53,6 +54,9 @@ init(Next) ->
 fileop({file,open_dialog,Prop,Cont}, _Next) ->
     Title = proplists:get_value(title, Prop, ?__(1,"Open")),
     file_dialog(?OP_READ, Prop, Title, Cont);
+fileop({file,font_dialog,Prop,Cont}, _Next) ->
+    Title = proplists:get_value(title, Prop, ?__(3,"Font Selection")),
+    file_dialog(?OP_FONT, Prop, Title, Cont);
 fileop({file,save_dialog,Prop,Cont}, _Next) ->
     Title = proplists:get_value(title, Prop, ?__(2,"Save")),
     file_dialog(?OP_WRITE, Prop, Title, Cont);

--- a/plugins_src/wx_file/wp8_file.erl
+++ b/plugins_src/wx_file/wp8_file.erl
@@ -33,6 +33,8 @@ init(Next) ->
 fileop({file,open_dialog,Prop,Cont}, _Next) ->
     Title = proplists:get_value(title, Prop, ?__(1,"Open")),
     file_dialog(?wxFD_OPEN, Prop, Title, Cont);
+fileop({file,font_dialog,Prop,Cont}, Next) ->
+    fileop({file,open_dialog,Prop,Cont}, Next);  % foward the call to open dialog
 fileop({file,save_dialog,Prop,Cont}, _Next) ->
     Title = proplists:get_value(title, Prop, ?__(2,"Save")),
     file_dialog(?wxFD_SAVE, Prop, Title, Cont);


### PR DESCRIPTION
Forced Windows to show the old style Font dialog for the font selection in the Text primitive dialog box.

OBS: It was discussed in this thread: http://www.wings3d.com/forum/showthread.php?tid=594
