### PR TITLE
Support for save/restore the last view settings of a project

### DIFF
--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -288,6 +288,8 @@ confirmed_new(#st{file=File}=St) ->
 
 new(#st{saved=true}=St0) ->
     St1 = clean_st(St0#st{file=undefined}),
+    %% clean_st/1 will remove all saved view, but will not reset the view. For a new project we should reset it. 
+    wings_view:reset(),
     St2 = clean_images(wings_undo:init(St1)),
     St = wings_shape:create_folder_system(St2),
     wings_u:caption(St),


### PR DESCRIPTION
People have already asked for this resource, but I had missing it many times. It's important be able to get the camera back to the last position before a project has been closed.

NOTE: Added support to save and restore the last view settings of a project.
