### PR TITLE
New Absolute Command - Rotate

### DIFF
--- a/plugins_src/commands/Makefile
+++ b/plugins_src/commands/Makefile
@@ -31,6 +31,7 @@ endif
 MODULES= \
 	wpc_absolute_move \
 	wpc_absolute_scale \
+	wpc_absolute_rotate \
 	wpc_ambocc \
 	ambocc_gl2 \
 	wpc_arc_intersect \

--- a/plugins_src/commands/wpc_absolute_rotate.erl
+++ b/plugins_src/commands/wpc_absolute_rotate.erl
@@ -1,0 +1,570 @@
+%%
+%%  wpc_absolute_rotate.erl --
+%%
+%%     Plug-in for rotate -> absolute
+%%
+%%  Copyright (c) 2014 Micheus
+%%
+%%  See the file "license.terms" for information on usage and redistribution
+%%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+%%
+%%     $Id$
+%%
+-module(wpc_absolute_rotate).
+
+-include("wings.hrl").
+
+-export([init/0,menu/2,command/2]).
+
+%%%
+%%% plugin interface
+%%%
+
+init() -> true.
+
+menu({Mode},Menu) when Mode == vertex; Mode == edge; Mode == face; Mode == body ->
+    parse(Menu, Mode);
+menu(_,Menu) ->
+    Menu.
+
+parse(Menu, Mode) ->
+    lists:reverse(parse(Menu, Mode, [], false)).
+
+parse([], _, NewMenu, true) ->
+    NewMenu;
+parse([], Mode, NewMenu, false) ->
+    [draw(all, Mode), separator|NewMenu];
+parse([{Name, {absolute, Commands}}|Rest], Mode, NewMenu, false) ->
+    parse(Rest, Mode, [{Name, {absolute, Commands++draw(menu, Mode)}}|NewMenu], true);
+parse([separator|Rest], Mode, NewMenu, false) ->
+    parse(Rest, Mode, [separator, draw(all, Mode)|NewMenu], true);
+parse([Elem|Rest], Mode, NewMenu, Found) ->
+    parse(Rest, Mode, [Elem|NewMenu], Found).
+
+draw(all, Mode) ->
+    {?__(1, "Absolute Commands"), {absolute, draw(menu, Mode)}};
+draw(menu, Mode) ->
+    [{?__(2,"Rotate"),rotate_fun(Mode),
+      {?__(3,"Rotate selection and align reference and target elements."),
+       ?__(4,"Rotate selection and align reference and target elements by using two reference axis."),
+       ?__(5,"Rotate selection and display numeric entry.")},[]}].
+
+rotate_fun(Mode) ->
+    fun(1, _Ns) ->
+	    {Mode,{absolute,lrotate}};
+       (2, _Ns) ->
+	    {Mode,{absolute,mrotate}};
+       (3, _Ns) ->
+	    {Mode,{absolute,rrotate}};
+       (_, _) -> ignore
+    end.
+
+command({_,{absolute,Mode}},St) when Mode == lrotate; Mode == mrotate; Mode == rrotate ->
+            case Mode of
+                lrotate -> wings:ask(selection_ask([from_axis,to_axis,reference,axis_point]), St, fun lrotate/2);
+                mrotate -> wings:ask(selection_ask([from_axis,to_axis,reference,target,axis_ref,axis_target]), St, fun mrotate/2);
+                rrotate -> wings:ask(selection_ask([from_axis,to_axis,reference,target,axis_ref,axis_target]), St, fun rrotate/2)
+            end;
+command(_,_) -> next.
+
+%%%
+%%% absolute rotate (LMB option)
+%%%
+lrotate({FromAxis, ToAxis, From, Axis}, St) ->
+    Sel = get_selection(false,St),
+    Angle = calc_angle(FromAxis, ToAxis, Axis),
+    {save_state,rotate([From,none,Axis,Angle],Sel,St)}.
+
+%%%
+%%% absolute rotate align axis and moving to target (MMB option)
+%%%
+mrotate({FromAxis, ToAxis, From, To, RefAxis, TargAxis}, St) ->
+    Sel = get_selection(false,St),
+    Norm = e3d_vec:normal(RefAxis,{0.0,0.0,0.0},TargAxis),
+    Angle0 = calc_angle(RefAxis, TargAxis, Norm),
+    St0=rotate([From,none,Norm,Angle0],Sel,St),
+
+    M=e3d_mat:rotate(Angle0,Norm),
+    FromAxis0=e3d_vec:norm(e3d_mat:mul_point(M, FromAxis)),
+    Angle1 = calc_angle(FromAxis0, ToAxis, TargAxis),
+    {save_state,rotate([From,To,TargAxis,Angle1],Sel,St0)}.
+
+%%%
+%%% absolute rotate with numeric entry (RMB option)
+%%%
+rrotate({_FromAxis, _ToAxis, _From, _To, _RefAxis, _TargAxis}=Params, #st{shapes=Shapes}=St) ->
+    Sel = get_selection(false,St),
+    Lights = get_lights(Sel,Shapes),
+    OneObject = check_single_obj(Sel),
+    SinglePoints = check_single_vert(Sel),
+    WholeObjects = if
+                       SinglePoints or Lights ->
+                           false;
+                       true ->
+                           check_whole_obj(St)
+                   end,
+    MoveObj = if
+                  WholeObjects or Lights -> duplionly;
+                  OneObject -> one;
+                  true -> many
+              end,
+    draw_window(erlang:append_element(Params,MoveObj),Sel,St).
+
+%%
+%% draw_window(Options,Selection,State)
+%%
+%% functions that draws interface and translates entered options for further processing
+%%  and calls translate(ProcessedOptions,Parameters,Selection,State)
+%%
+
+draw_window({_FromAxis, _ToAxis, From, To, _RefAxis, _TargAxis, MoveObj}=Options, Sel, #st{selmode=_SelMode}=St) ->
+    Frame1 = [{vframe, [draw_window1(center,To)]}],
+    Frame2 = [draw_window1(lock,default)],
+    Frame25 = [draw_window1(object,MoveObj)],
+    Frame3 = if
+                 MoveObj =/= duplionly ->
+                     [draw_window1(duplicate,true)];
+                 true ->
+                     []
+             end,
+    Frame35 = [draw_window1(distance,e3d_vec:dist(To,From))],
+    Frame4 = [draw_window1(dup_rt,default)]++
+             [draw_window1(dup_around,default)]++
+             [draw_window1(twist,default)]++
+             [draw_window1(scale,default)],
+
+    Frame5 = if
+                 Frame2 =/= [] ->
+                     [{hframe,Frame1++Frame2}]++[{vframe,Frame25++Frame3++Frame35}];
+                 true ->
+                     [{vframe,Frame1++Frame25++Frame3++Frame35}]
+             end,
+    Frame = [{vframe,Frame5++Frame4++[separator,draw_window1(reference,From)]}],
+    Name = draw_window1(name,default),
+    wings_ask:dialog(Name, {preview,Frame},
+       fun (cancel) -> St;
+           ({dialog_preview,Rotate}) ->
+               {preview,St,translate(Rotate,Options,Sel,St)};
+           (Rotate) ->
+               {commit,St,translate(Rotate,Options,Sel,St)}
+       end).
+
+draw_window1(name,_) ->
+    ?__(1,"Absolute rotate options");
+draw_window1(center,{XC,YC,ZC}) ->
+    {vframe,[
+        {hframe,[{label,?__(2,"Set position")++":"}]},
+        {hframe,[{label,"X:"},{text,XC,[{key,x},disable(lx)]}]},
+        {hframe,[{label,"Y:"},{text,YC,[{key,y},disable(ly)]}]},
+        {hframe,[{label,"Z:"},{text,ZC,[{key,z},disable(lz)]}]}
+    ]};
+draw_window1(distance,Dist) ->
+    {vframe,[
+      {hframe,[
+        {label,?__(10,"Distance")++":"},
+        {text,Dist,[{key,dist}]}
+      ],[disable(dup_rt)]}
+    ]};
+draw_window1(object,one) ->
+    {vframe, [{?__(3,"Move object"),false,[{key,all}]}]};
+draw_window1(object,many) ->
+    {vframe, [{?__(4,"Move objects"),false,[{key,all}]}]};
+draw_window1(object,duplionly) ->
+    draw_window1(duplicate,false);
+draw_window1(duplicate,CheckAll) when is_boolean(CheckAll) ->
+    Label = if
+        CheckAll -> [disable(all)];
+        true -> []
+    end,
+    {vframe,[
+      {hframe,[
+        {text,0,[{key,dupli},{range,{0,infinity}},Label]},
+        {label,?__(5,"Duplicates")}
+      ],[disable(dupli)]}
+    ]};
+draw_window1(dup_rt,_) ->
+    {vframe,[
+      {hframe,[
+        {label,?__(9,"Between reference and target")++" "},
+        {"",false,[{key,dup_rt}]}
+      ],[disable(dup_rt)]}
+    ]};
+draw_window1(twist,_) ->
+    {vframe,[
+        {vframe,[
+          {hframe,[
+            {label,?__(14,"Degrees")},
+            {text,0.0,[{key,twist_ax},{width,5}]}
+          ]},
+          {hradio,[
+            {?__(15,"Target"),target},
+            {?__(16,"From previous object"),object}],target,
+            [{title,?__(13,"Reference axis")},{key,twist_op_ax}]},
+          {hradio,[
+            {?__(18,"Preserve"),preserve},
+            {?__(19,"Aligned to direction vector"),direction}],direction,
+            [{title,?__(20,"Objects alignment")},{key,twist_ob_al},
+             {info, ?__(21,"Direction vector is defined by the source-target segment")}]}
+      ],[{title, ?__(12,"Around the target axis")}]},
+        {vframe,[
+          {hframe,[
+            {label,?__(22,"Degrees")},
+            {text,0.0,[{key,twist_dir},{width,5}]}
+          ]}
+      ],[{title, ?__(17,"Around the direction vector")}]}
+    ],[{title,?__(11,"Twist options")},disable(dup_rt)]};
+draw_window1(dup_around,_) ->
+    {vframe,[
+      {hframe,[
+        {text,0.0,[{key,degrees},{width,5}]},
+        {label,?__(24,"Degrees")++"  "},
+        {text,0,[{key,steps},{width,3},{range,{0,infinity}}]},
+        {label,?__(25,"Steps")}
+      ],[disable(dupli)]}
+    ],[{title,?__(23,"Duplicate around options")}]};
+draw_window1(scale,_) ->
+    {vframe,[
+      {hframe,[
+        {label,?__(28,"In")++":"},
+        {text,100.0,[{key,scl_in},{width,5},{range,{0.0001,infinity}}]},
+        {label,"%"++"  "},
+        {label,?__(29,"Out")++":"},
+        {text,100.0,[{key,scl_out},{width,5},{range,{0.0001,infinity}}]},
+        {label,"%"}
+      ],[{title, ?__(27,"Objects")}]},
+      {hframe,[
+        {label,?__(28,"In")++":"},
+        {text,100.0,[{key,scl_seg_in},{width,5},{range,{0.0001,infinity}}]},
+        {label,"%"++"  "},
+        {label,?__(29,"Out")++":"},
+        {text,100.0,[{key,scl_seg_out},{width,5},{range,{0.0001,infinity}}]},
+        {label,"%"}
+      ],[{title, ?__(30,"Distance segments")}]}
+    ],[{title,?__(26,"Scale options")},disable(dup_rt)]};
+draw_window1(lock, _) ->
+    {vframe,[
+        {hframe,[{label,?__(8,"Lock")++":"}]},
+        {hframe,[{"",false,[{key,lx}]}]},
+        {hframe,[{"",false,[{key,ly}]}]},
+        {hframe,[{"",false,[{key,lz}]}]}
+    ]};
+draw_window1(reference,{X,Y,Z}) ->
+    {label,?__(7,"Reference point is") ++ ": (" ++
+    wings_util:nice_float(X)++", "++
+    wings_util:nice_float(Y)++", "++
+    wings_util:nice_float(Z)++")"}.
+
+disable(all) ->
+    {hook,fun (is_disabled, {_Var,_I,Store}) ->
+                  not gb_trees:get(all, Store);
+              (_, _) -> void
+          end};
+disable(dupli) ->
+    {hook,fun (is_disabled, {_Var,_I,Store}) ->
+                  ((gb_trees:is_defined(all,Store)) andalso (not gb_trees:get(all, Store)));
+              (_, _) -> void
+          end};
+disable(dup_rt) ->
+    {hook,fun (is_disabled, {_Var,_I,Store}) ->
+                  (gb_trees:get(dupli, Store) < 1) and
+                  (not (gb_trees:is_defined(all,Store) andalso (gb_trees:get(all, Store))));
+              (_, _) -> void
+          end};
+disable(Other) ->
+    {hook,fun (is_disabled, {_Var,_I,Store}) ->
+                  gb_trees:is_defined(Other,Store) andalso gb_trees:get(Other, Store);
+              (_, _) -> void
+          end}.
+
+lookup(Key, List, Default) ->
+   case lists:keysearch(Key, 1, List) of
+      {value,{_,Value}} -> Value;
+      _ -> Default
+   end.
+
+translate(Options, {FromAxis, ToAxis, {CX,CY,CZ}=From, _To, RefAxis, TargAxis, _}, _Sel, St) ->
+    Obj = lookup(all,Options,true),
+    Sel = get_selection(Obj,St),
+    X = lookup(x, Options, 0.0),
+    Y = lookup(y, Options, 0.0),
+    Z = lookup(z, Options, 0.0),
+    NX = case lookup(lx,Options,false) of
+           true -> CX;
+           _ -> X
+        end,
+    NY = case lookup(ly,Options,false) of
+           true -> CY;
+           _ -> Y
+        end,
+    NZ = case lookup(lz, Options, false) of
+           true -> CZ;
+           _ -> Z
+        end,
+    Dist = lookup(dist, Options, 0.0),
+    DirVec = e3d_vec:norm_sub({NX,NY,NZ},From),
+    Obj = lookup(all,Options,true),
+    Dupli = case lookup(dupli,Options,0) of
+                N when Obj -> N;
+                _ -> 0
+            end,
+    Dup_rt = lookup(dup_rt,Options,false),
+    TwistAx = lookup(twist_ax,Options,0.0),
+    TwOpAx = lookup(twist_op_ax,Options,target),
+    TwistDir = lookup(twist_dir,Options,0.0),
+    TwObjAl = lookup(twist_ob_al,Options,direction),
+    Steps = lookup(steps,Options,0.0),
+    Degrees = lookup(degrees,Options,0.0),
+    SclIn = lookup(scl_in,Options,100.0),
+    SclOut = lookup(scl_out,Options,100.0),
+    SclSegIn = lookup(scl_seg_in,Options,100.0),
+    SclSegOut = lookup(scl_seg_out,Options,100.0),
+    SclOff = if (Dupli > 0) ->
+        (SclOut-SclIn)/Dupli;
+    true ->
+        0.0
+    end,
+    SclSegOff = if (Dupli > 0) ->
+        (SclSegOut-SclSegIn)/Dupli;
+    true ->
+        0.0
+    end,
+    rotate(FromAxis,ToAxis,RefAxis,TargAxis,Dupli,Dup_rt,
+           {TwistAx,TwOpAx,TwistDir,TwObjAl},Steps,Degrees,
+           {SclIn,SclOff,SclSegIn,SclSegOff},DirVec,Dist,[From,{NX,NY,NZ},Dupli],Sel,St).
+
+rotate(_,[],St0) ->
+    St0;
+rotate([From,To,TargAxis,Angle]=Params,[{Obj,Vset}|Rest],#st{shapes=Shapes}=St) ->
+    #we{vp=Vtab} = We = gb_trees:get(Obj, Shapes),
+    NewVtab = execute_rotate([From,To,TargAxis,Angle,none],Vset,Vtab),
+    NewShapes = gb_trees:update(Obj,We#we{vp=NewVtab},Shapes),
+    rotate(Params,Rest,St#st{shapes=NewShapes}).
+
+%% Absolute Rotate - RMB option routine
+rotate(_,_,_,_,_,_,_,_,_,_,_,_,_,[],St) -> St;
+rotate(FromAx,ToAx,RefAx,TargAx,Dupli,Dup_rt,TwistOpt,Steps,Degrees,SclOpt,DirVec,Dist,[From0,To0,Du],[{Obj0,Vset}|Rest]=Sel,#st{shapes=Shapes0}=St0) ->
+    {TwistAx,TwOpAx,TwistDir,TwObjAl} = TwistOpt,
+    {SclIn,SclOff,SclSegIn,SclSegOff} = SclOpt,
+    We0 = gb_trees:get(Obj0, Shapes0),
+    #st{shapes=Shapes1,onext=Oid} = St1 = if
+                                              Du > 0 ->
+                                                  wings_shape:insert(We0, copy, St0);
+                                              true ->
+                                                  St0
+                                          end,
+    We1 = if
+        Du > 0 ->
+            Obj1 = Oid-1,
+            gb_trees:get(Obj1, Shapes1);
+        true ->
+            Obj1 = Obj0,
+            We0
+    end,
+    #we{vp=Vtab0} = We1,
+    Norm = e3d_vec:normal(RefAx,{0.0,0.0,0.0},TargAx),
+    Angle0 = calc_angle(RefAx, TargAx, Norm),
+    NewVtab0 = execute_rotate([From0,none,Norm,Angle0,none],Vset,Vtab0),
+
+    Scale = SclIn+(SclOff*Du),
+    M = e3d_mat:rotate(Angle0,Norm),
+    FromAx0 = e3d_vec:norm(e3d_mat:mul_point(M, FromAx)),
+    Angle1 = calc_angle(FromAx0, ToAx, TargAx),
+    NewVtab = execute_rotate([From0,To0,TargAx,Angle1,Scale],Vset,NewVtab0),
+
+    Vtab = if
+        Du > 0 ->  % it has Duplicate set
+            ScaleSeg = SclSegIn+(SclSegOff*Du),
+            CalcDist=fun(Dist0, 0.0) -> Dist0;
+                (Dist0, _) -> Dist0*ScaleSeg/100.0
+            end,
+
+            NewVtab3 = if TwistDir =/= 0.0 ->  % object twisted around the direction vector
+                execute_rotate([To0,none,DirVec,TwistDir*Du,none],Vset,NewVtab);
+            true ->
+                NewVtab
+            end,
+
+            ObjPos = if TwistAx =:= 0.0 ->  % no twist angle defined
+                SegDist = if Dup_rt ->  % Duplicate between source->target
+                    -Dist/Dupli*Du;
+                true ->
+                    Dist*Du
+                end,
+                e3d_vec:add(From0,e3d_vec:mul(DirVec,CalcDist(SegDist,SclSegOff)));
+            true ->
+                DirVec0 = case TwOpAx of
+                    target ->  % Target
+                        M0=e3d_mat:rotate(TwistAx/Dupli*Du,TargAx),
+                        e3d_vec:norm(e3d_mat:mul_point(M0, DirVec));
+                    _ ->  % From previous object
+                        DirVec
+                end,
+                ObjPos0 = case Dup_rt of  % Duplicate between source->target
+                    true ->
+                        ObjPos9 = case TwOpAx of  % Twist reference axis:
+                            target ->  % twist reference axis: Target
+                                e3d_vec:mul(DirVec0,CalcDist(Dist/Dupli*Du,SclSegOff));  %%% OK - target
+                            _ ->
+                                calc_twisted_location(DirVec0,CalcDist(Dist/Dupli,SclSegOff),TargAx,TwistAx,Du)  %%% OK - from previous object
+                        end,
+                        e3d_vec:mul(ObjPos9,-1.0);
+                    _ ->
+                        case TwOpAx of  % Twist reference axis:
+                            target ->  % Target
+                                e3d_vec:mul(DirVec0,CalcDist(Dist*Du,SclSegOff));  %%% OK - target
+                            _ ->  % From previous object
+                                calc_twisted_location(DirVec0,CalcDist(Dist,SclSegOff),TargAx,TwistAx,Du)  %%% OK - from previous object
+                        end
+                end,
+                e3d_vec:add(From0,ObjPos0)
+            end,
+            NewVtab2 = case TwObjAl of
+                direction ->
+                    case TwOpAx of  % Twist reference axis:
+                        target ->  % Target
+                            execute_rotate([To0,none,TargAx,TwistAx/Dupli*Du,none],Vset,NewVtab3);  %%% OK - target
+                        _ ->  % From previous object
+                            execute_rotate([To0,none,TargAx,TwistAx*Du,none],Vset,NewVtab3)  %%% OK - from previous object
+                    end;
+                _ ->
+                    NewVtab3
+            end,
+            execute_translate([From0,ObjPos],Vset,NewVtab2);  %%% OK - target / from previous object
+    true ->
+        NewVtab
+    end,
+
+    NewWe = We1#we{vp=Vtab},
+    NewShapes = gb_trees:update(Obj1,NewWe,Shapes1),
+    NewSt0=St1#st{shapes=NewShapes},
+
+    NewSt = if
+        (Steps > 0) and (Degrees =/= 0.0) ->  % duplicating around
+            Deg0 = Degrees/(Steps+1),
+            lists:foldr(fun(Step, St2) ->
+                #st{shapes=Shp1,onext=Oid1} = St3 = wings_shape:insert(NewWe, copy, St2),
+                Obj2=Oid1-1,
+                We2=gb_trees:get(Obj2, Shp1),
+                NewVtab1 = execute_rotate([To0,none,TargAx,Deg0*Step,none],Vset,Vtab),
+                NewWe1 = We2#we{vp=NewVtab1},
+                NewShapes0 = gb_trees:update(Obj2,NewWe1,Shp1),
+                St3#st{shapes=NewShapes0}
+            end,NewSt0,lists:seq(1,Steps));
+    true ->
+        NewSt0
+    end,
+
+    if Du > 0 ->
+        rotate(FromAx,ToAx,RefAx,TargAx,Dupli,Dup_rt,TwistOpt,Steps,Degrees,SclOpt,DirVec,Dist,[From0,To0,Du-1],Sel,NewSt);
+    true ->
+        rotate(FromAx,ToAx,RefAx,TargAx,Dupli,Dup_rt,TwistOpt,Steps,Degrees,SclOpt,DirVec,Dist,[From0,To0,Dupli],Rest,NewSt)
+    end.
+
+calc_twisted_location(SDir, SLen, Axis, Ang, Dup) ->
+    calc_twisted_location_0(SDir,SLen,Axis,Ang,Dup, {0.0,0.0,0.0}).
+
+calc_twisted_location_0(_, _, _, _, 0, Pto) -> Pto;
+calc_twisted_location_0(SDir1, SLen, Axis, Ang, Dup, Pto) ->
+    M=e3d_mat:rotate(Ang,Axis),
+    SDir0=e3d_vec:mul(e3d_vec:norm(SDir1),SLen),
+    SDir=e3d_mat:mul_point(M, SDir0),
+    calc_twisted_location_0(SDir,SLen,Axis,Ang,Dup-1,e3d_vec:add(Pto,SDir)).
+
+execute_rotate([From, To, Axis, Angle, Scale], Vset, Vtab) ->
+    {Cx,Cy,Cz}=From,
+    M0 = case To of
+        {Cxo,Cyo,Czo} -> e3d_mat:translate(Cxo,Cyo,Czo);
+        _ -> e3d_mat:translate(Cx, Cy, Cz)
+    end,
+    M2 = case Scale of
+        none -> M0;
+        _ ->
+            S = Scale/100.0,
+            e3d_mat:mul(M0, e3d_mat:scale(S,S,S))
+    end,
+    M1 = e3d_mat:mul(M2, e3d_mat:rotate(Angle, Axis)),
+    M = e3d_mat:mul(M1, e3d_mat:translate(-Cx, -Cy, -Cz)),
+    calc_transformation(M, Vset, Vtab).
+
+execute_translate([{Sx,Sy,Sz}, {Dx,Dy,Dz}], Vset, Vtab) ->
+    M0 = e3d_mat:translate(-Sx,-Sy,-Sz),
+    M = e3d_mat:mul(M0, e3d_mat:translate(Dx,Dy,Dz)),
+    calc_transformation(M, Vset, Vtab).
+
+calc_transformation(M, Vset, Vtab) ->
+    lists:foldl(fun(V, Acc) ->
+        Vs0=array:get(V,Acc),
+        Vs=e3d_mat:mul_point(M, Vs0),
+        array:set(V,Vs,Acc)
+    end, Vtab, gb_sets:to_list(Vset)).
+
+%%%
+%%% some helpful test and investigation functions
+%%%
+calc_angle(FromAxis, ToAxis, Axis) ->
+    FromNorm = e3d_vec:normal(Axis,{0.0,0.0,0.0},FromAxis),
+    ToNorm = e3d_vec:normal(Axis,{0.0,0.0,0.0},ToAxis),
+    Degree = e3d_vec:degrees(ToNorm,FromNorm),
+    Norm = e3d_vec:normal(ToNorm,{0.0,0.0,0.0},FromNorm),
+    Size = abs(e3d_vec:len(e3d_vec:add(Axis,Norm))),
+    if Size < 1.0 -> -Degree;
+      true -> Degree
+    end.
+
+get_selection(true,St) ->
+    St0=wings_sel_conv:mode(body, St),
+    get_selection(false,St0);
+get_selection(_,#st{selmode=SelMode}=St) ->
+    #st{sel=Sel} = case SelMode of
+        vertex -> St;
+        _ -> wings_sel_conv:mode(vertex,St)
+    end,
+    Sel.
+
+selection_ask(Asks) ->
+    Ask = selection_ask(Asks,[]),
+    {Ask,[],[],[vertex, edge, face, body]}.
+
+selection_ask([],Ask) -> lists:reverse(Ask);
+selection_ask([reference|Rest],Ask) ->
+    Desc = ?__(1,"Define point through which rotate axis will pass"),
+    selection_ask(Rest,[{point,Desc}|Ask]);
+selection_ask([target|Rest],Ask) ->
+    Desc = ?__(2,"Select target point for snap operation"),
+    selection_ask(Rest,[{point,Desc}|Ask]);
+selection_ask([from_axis|Rest],Ask) ->
+    Desc = ?__(3,"Define reference element on selection (to be rotated)"),
+    selection_ask(Rest,[{axis,Desc}|Ask]);
+selection_ask([to_axis|Rest],Ask) ->
+    Desc = ?__(4,"Define target element on stationary object"),
+    selection_ask(Rest,[{axis,Desc}|Ask]);
+selection_ask([axis_point|Rest],Ask) ->
+    Desc = ?__(5,"Define rotate axis. (Both reference and target elements lie on one of its axial planes)"),
+    selection_ask(Rest,[{axis,Desc}|Ask]);
+selection_ask([axis_ref|Rest],Ask) ->
+    Desc = ?__(6,"Define rotate axis for reference element (it will match to axis for target element)"),
+    selection_ask(Rest,[{axis,Desc}|Ask]);
+selection_ask([axis_target|Rest],Ask) ->
+    Desc = ?__(7,"Define rotate axis for target element"),
+    selection_ask(Rest,[{axis,Desc}|Ask]).
+
+check_whole_obj(#st{selmode=SelMode}=St0) ->
+    St1 = wings_sel_conv:mode(body,St0),
+    St2 = wings_sel_conv:mode(SelMode,St1),
+    St2#st.sel == St0#st.sel.
+
+get_lights(Sel,Shapes) ->
+    get_lights(Sel,Shapes,true).
+
+get_lights([],_,Lights) ->
+    Lights;
+get_lights([{Obj,_}|Rest],Shapes,Lights) ->
+    We = gb_trees:get(Obj, Shapes),
+    get_lights(Rest,Shapes,Lights and ?IS_LIGHT(We)).
+
+check_single_obj([{_,_}]) -> true;
+check_single_obj(_) -> false.
+
+check_single_vert(L) ->
+    lists:all(fun({_,GbSet}) -> gb_sets:size(GbSet) =:= 1 end, L).
+

--- a/src/wings_vec.erl
+++ b/src/wings_vec.erl
@@ -17,6 +17,7 @@
 
 -define(NEED_OPENGL, 1).
 -define(NEED_ESDL, 1).
+-define(SEP, [160,160,160,160,160]).    %Equivalent to two and a half space character width.
 -include("wings.hrl").
 
 -import(lists, [reverse/1,member/2,last/1]).
@@ -194,18 +195,22 @@ handle_event_3(Ev, Ss, St) -> handle_event_4(Ev, Ss, St).
 
 handle_event_4({new_state,St}, #ss{f=Check}=Ss, _St0) ->
     case Check(check, St) of
-	{Vec,Msg} -> 
+	{Vec,Msg} ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
-	[{Vec,Msg}] -> 
+	[{Vec,{Msg,SwMsg}}] ->
+	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=SwMsg}, St);
+	[{Vec,Msg}] ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
 	[{Vec,{Msg,SwMsg}},{AltVec,_}] ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=AltVec,sw_msg=SwMsg}, St)
     end;
 handle_event_4({update_state,St}, #ss{f=Check}=Ss, _St0) ->
     case Check(check, St) of
-	{Vec,Msg} -> 
+	{Vec,Msg} ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
-	[{Vec,Msg}] -> 
+	[{Vec,{Msg,SwMsg}}] ->
+	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=SwMsg}, St);
+	[{Vec,Msg}] ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
 	[{Vec,{Msg,SwMsg}},{AltVec,_}] ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=AltVec,sw_msg=SwMsg}, St)
@@ -264,7 +269,7 @@ handle_event_4(_Event, Ss, St) ->
 
 temp_selection(X, Y, St0) ->
     case St0 of
-	#st{sel=[{_,_}|_]} -> 
+	#st{sel=[{_,_}|_]} ->
 	    none;
 	_ ->
 	    case wings_pick:do_pick(X, Y, St0) of
@@ -344,9 +349,13 @@ redraw(#ss{info=Info,f=Message,vec=Vec}=Ss, St) ->
     gl:popAttrib(),
     wings_wm:current_state(St).
 
-right_message(#ss{alt_vec=none}) -> [];
+right_message(#ss{alt_vec=none,sw_msg=none}) -> [];
+right_message(#ss{alt_vec=none,sw_msg=Msg}) -> Msg;
 right_message(#ss{sw_msg=Msg}) ->
     "[1] " ++ Msg.
+
+invert_message() ->
+    "[2] " ++ ?__(1,"Invert orientation").
 
 filter_sel_command(#ss{selmodes=Modes}=Ss, #st{selmode=Mode}=St) ->
     case member(Mode, Modes) of
@@ -359,13 +368,21 @@ handle_key(#keyboard{sym=$1}, #ss{vec=Vec,alt_vec=Vec}, St) ->
     keep;
 handle_key(#keyboard{sym=$1}, #ss{f=Check}=Ss, St) ->
     case Check(check, St) of
-	{Vec,Msg} -> 
+	{Vec,Msg} ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
-	[{Vec,Msg}] -> 
+	[{Vec,Msg}] ->
+	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
+	[{Vec,{Msg,SwMsg}}] ->
+	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=SwMsg}, St);
+	[{Vec,Msg}] ->
 	    get_event(Ss#ss{info=Msg,vec=Vec,alt_vec=none,sw_msg=none}, St);
 	[_,{AltVec,{Msg,SwMsg}}] ->
 	    get_event(Ss#ss{info=Msg,vec=AltVec,alt_vec=AltVec,sw_msg=SwMsg}, St)
     end;
+handle_key(#keyboard{sym=$2}, #ss{vec={Center,Vec},alt_vec=none}=Ss, St) ->
+	get_event(Ss#ss{vec={Center,e3d_vec:neg(Vec)}}, St);
+handle_key(#keyboard{sym=$2}, #ss{vec={Center,Vec},alt_vec={Center,AltVec}}=Ss, St) ->
+	get_event(Ss#ss{vec={Center,e3d_vec:neg(Vec)},alt_vec={Center,e3d_vec:neg(AltVec)}}, St);
 handle_key(#keyboard{sym=27}, _, _) ->		%Escape
     wings_wm:later({action,{secondary_selection,abort}});
 handle_key(_, _, _) -> next.
@@ -429,7 +446,20 @@ build_result_1(Res, Cb, St0) ->
 
 check_vector(#st{sel=[]}) -> {none,""};
 
-check_vector(#st{selmode=vertex,sel=[{_Ob1,Sel1},{_Ob2,Sel2},{_Ob3,Sel3}]}=St) ->
+check_vector(St) ->
+    case check_vector_0(St) of
+	[{none,_}]=Res ->
+	    Res;
+	[{Vec,Msg}] ->
+	    [{Vec,{Msg,invert_message()}}];
+	[{Vec,{InfMsg,SwMsg}},{AltVec,{InfMsg0,SwMsg0}}] ->
+	    [{Vec,{InfMsg,SwMsg++?SEP++invert_message()}},
+	     {AltVec,{InfMsg0,SwMsg0++?SEP++invert_message()}}];
+    Res ->
+        Res
+	end.
+
+check_vector_0(#st{selmode=vertex,sel=[{_Ob1,Sel1},{_Ob2,Sel2},{_Ob3,Sel3}]}=St) ->
     VertNum = gb_sets:size(Sel1) + gb_sets:size(Sel2) + gb_sets:size(Sel3),
     case VertNum of
       3 ->
@@ -444,7 +474,7 @@ check_vector(#st{selmode=vertex,sel=[{_Ob1,Sel1},{_Ob2,Sel2},{_Ob3,Sel3}]}=St) -
         {none,Str}
     end;
 
-check_vector(#st{selmode=vertex,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}=St) ->
+check_vector_0(#st{selmode=vertex,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}=St) ->
     SelSize = gb_sets:size(Sel0) + gb_sets:size(Sel1),
     case SelSize of
       2 ->
@@ -460,12 +490,11 @@ check_vector(#st{selmode=vertex,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}=St) ->
                         end,[],St),
         Positions = lists:merge(PosList),
         get_vec(vertex,plane,Positions);
-
       _ ->
         Str = guard_string(),
         {none,Str}
     end;
-check_vector(#st{selmode=edge,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
+check_vector_0(#st{selmode=edge,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
         We0 = gb_trees:get(Id0,Shs),
         We1 = gb_trees:get(Id1,Shs),
         EL0 = gb_sets:to_list(Sel0),
@@ -475,7 +504,7 @@ check_vector(#st{selmode=edge,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
           _ -> get_vec(edge, [{EL0}, {EL1}], [We0, We1])
         end;
 
-check_vector(#st{selmode=Mode,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
+check_vector_0(#st{selmode=Mode,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
     SelSize = gb_sets:size(Sel0) + gb_sets:size(Sel1),
     case SelSize of
       2 ->
@@ -489,12 +518,12 @@ check_vector(#st{selmode=Mode,sel=[{Id0,Sel0},{Id1,Sel1}],shapes=Shs}) ->
         {none,Str}
     end;
 
-check_vector(#st{selmode=Mode,sel=[{Id,Elems0}],shapes=Shs}) ->
+check_vector_0(#st{selmode=Mode,sel=[{Id,Elems0}],shapes=Shs}) ->
     We = gb_trees:get(Id, Shs),
     Elems = gb_sets:to_list(Elems0),
     get_vec(Mode, Elems, We);
 
-check_vector(_) ->
+check_vector_0(_) ->
     Str = guard_string(),
     {none,Str}.
 
@@ -518,7 +547,7 @@ get_vec(vertex,plane,Positions) ->
         [Vp1,Vp2,Vp3] ->
             Vec0 = e3d_vec:sub(Vp1,Vp2),
             Vec1 = e3d_vec:sub(Vp1,Vp3),
-            Vec = e3d_vec:cross(Vec0,Vec1),
+            Vec = e3d_vec:norm(e3d_vec:cross(Vec0,Vec1)),
             Center = e3d_vec:average(Positions),
             [{{Center,Vec},?__(13,"3-point perp. normal saved as axis.")}];
         _ -> {none,?__(27,"Vertices cannot share coordinates when defining a 3 point plane normal")}
@@ -549,7 +578,7 @@ get_vec(edge, [{Edges1},{Edges2}], [We1,We2]) ->
         LoopCenter2 = wings_vertex:center(Vs2, We2),
         Center = e3d_vec:average(LoopCenter1, LoopCenter2),
         Vec = e3d_vec:norm_sub(LoopCenter1, LoopCenter2),
-        [{{Center,Vec},?__(28,"Axis between edge loop centers saved as axis.")}];		
+        [{{Center,Vec},?__(28,"Axis between edge loop centers saved as axis.")}];
     _Other ->
         [{none,guard_string()}]
     end;
@@ -640,7 +669,7 @@ get_vec(edge, [Edge1,Edge2], #we{es=Etab,vp=Vtab}) ->
 %% Use edge-loop normal.
 get_vec(edge, Edges, #we{vp=Vtab}=We) ->
     case wings_edge_loop:edge_loop_vertices(Edges, We) of
-	[Vs] -> 
+	[Vs] ->
 	    Center = wings_vertex:center(Vs, We),
 	    Vec = wings_face:face_normal_ccw(Vs, Vtab),
 	    [{{Center,Vec},?__(6,"Edge loop normal saved as axis.")}];
@@ -649,7 +678,7 @@ get_vec(edge, Edges, #we{vp=Vtab}=We) ->
 	    LoopCenter2 = wings_vertex:center(Vs2, We),
 		Center = e3d_vec:average(LoopCenter1, LoopCenter2),
 	    Vec = e3d_vec:norm_sub(LoopCenter1, LoopCenter2),
-	    [{{Center,Vec},?__(28,"Axis between edge loop centers saved as axis.")}];		
+	    [{{Center,Vec},?__(28,"Axis between edge loop centers saved as axis.")}];
 	_Other ->
 	    [{none,?__(29,"Multi-edge selection must form either a single or two closed edge loops.")}]
     end;
@@ -683,7 +712,7 @@ get_vec(vertex, [_,_,_]=Vs, #we{vp=Vtab}=We) ->
 get_vec(vertex, Vs0, #we{vp=Vtab}=We) ->
     Edges = find_edges(Vs0, We),
     case wings_edge_loop:edge_loop_vertices(Edges, We) of
-	[Vs] -> 
+	[Vs] ->
 	    Center = wings_vertex:center(Vs, We),
 	    Vec = wings_face:face_normal_cw(Vs, Vtab),
 	    [{{Center,Vec},?__(14,"Vertex loop normal saved as axis.")}];


### PR DESCRIPTION
A new resource Absolute Command->Rotate was added. It intend to give us precision in rotation operations we need to rotate elements to be aligned with a vector or plane. There are three option LMB,MMB and RMB, which MMB works like LMB plus run a snap operation and RMB - similar to Snap/Move - show up a dialog which will provide array options. Thanks to Arg Arg for help testing it [Micheus]

The wings_vec.erl was changed to enable the user change the "direction" of an "orientation" vector by adding the option "[2] Invert" to the text in the right side in the information line. The direction is something important for this new command.

The thread at Wings3d forum: http://www.wings3d.com/forum/showthread.php?tid=729

![rotate-lmb](http://i1330.photobucket.com/albums/w578/Micheus/Wings3D%20-%20Forum/rotate-LMB_zps9e0e9e33.png)
![rotate-mmb](http://i1330.photobucket.com/albums/w578/Micheus/Wings3D%20-%20Forum/rotate-MMB_zps18789128.png)