### PR TITLE
The table control now returns a selection list and the input values

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -1207,7 +1207,8 @@ build_textctrl(Ask, Def, Flags, {MaxSize, Validator}, Parent, Sizer) ->
 			  end
 		  end,
     case Type of
-	string ->
+	string -> ignore;
+        _ ->
 	    UpdateTextWheel =
 		fun(#wx{event=#wxMouse{type=mousewheel}=EvMouse}, _) ->
 			Str = text_wheel_move(Def,wxTextCtrl:getValue(Ctrl),EvMouse),
@@ -1219,9 +1220,7 @@ build_textctrl(Ask, Def, Flags, {MaxSize, Validator}, Parent, Sizer) ->
 				ignore
 			end
 		end,
-	    wxTextCtrl:connect(Ctrl, mousewheel, [{callback, UpdateTextWheel}]);
-	_ ->
-	    ignore
+	    wxTextCtrl:connect(Ctrl, mousewheel, [{callback, UpdateTextWheel}])
     end,
     UseHistory = fun(Ev, Obj) ->
 			 case use_history(Ev, Type, Ctrl) of

--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -536,6 +536,15 @@ get_curr_value(#in{type=text, def=Def, wx=Ctrl, validator=Validate}) ->
     Str = wxTextCtrl:getValue(Ctrl),
     validate(Validate, Str, Def);
 get_curr_value(#in{type=button, data=Data}) -> Data;
+get_curr_value(#in{type=table, def=Def, wx=Ctrl}) ->
+    Count = wxListCtrl:getItemCount(Ctrl),
+    {lists:foldl(
+        fun(N, Acc) ->
+            State = wxListCtrl:getItemState(Ctrl,N,?wxLIST_STATE_SELECTED),
+            if (State == ?wxLIST_STATE_SELECTED) -> Acc++[N];
+                true -> Acc
+            end
+        end,[],lists:seq(0,Count-1)), Def};
 get_curr_value(#in{type=value, data=Data})  -> Data.
 
 
@@ -1000,9 +1009,12 @@ build(Ask, {menu, Entries, Def, Flags}, Parent, Sizer, In) ->
 build(Ask, {table, [Header|Rows], Flags}, Parent, Sizer, In) ->
     Create =
 	fun() ->
+		Height = case proplists:get_value(max_rows, Flags) of
+		             undefined -> min((2+length(Rows))*25, 800);
+		             MaxR -> max(MaxR+1,5)*20
+		         end,
 		Options = [{style, ?wxLC_REPORT},
-			   {size, {min(tuple_size(Header)*80, 500),
-				   min((2+length(Rows))*25, 800)}}],
+			   {size, {min(tuple_size(Header)*80, 500), Height}}],
 		Ctrl = wxListCtrl:new(Parent, Options),
 		AddHeader = fun(HeadStr, Column) ->
 				    wxListCtrl:insertColumn(Ctrl, Column, HeadStr, []),
@@ -1030,10 +1042,10 @@ build(Ask, {table, [Header|Rows], Flags}, Parent, Sizer, In) ->
 		add_sizer(table, Sizer, Ctrl),
 		Ctrl
 	end,
-    create(Ask,Create),
-    %% [#in{key=proplists:get_value(key,Flags), def=Rows,
-    %% 	 type=table, wx=create(Ask,Create)}|In];
-    In;
+    %% create(Ask,Create),
+    [#in{key=proplists:get_value(key,Flags), def=Rows,
+     	 type=table, wx=create(Ask,Create)}|In];
+    %% In;
 
 build(Ask, {image, ImageOrFile}, Parent, Sizer, In) ->
     Create = fun() ->


### PR DESCRIPTION
The table control also returns a tuple value composed by a list of selected
item index and the original data values. As it used to be in the ESDL version.

The wings_dialog.erl was changed in order to enable the user to set the
max number of row in the table for a best look-and-feel. The best way to
calculate it would be getting the font size used by the control or the
its row height, but I couldn't find a direct/safe way get it.

We still need to find a way to change the values during a control event - as
it could be done in the past with {update,Store}. Dynamics dialogs requires
that all the time.