### PR TITLE
More bug fixes to version 1.5.3

### DIFF
--- a/plugins_src/autouv/auv_mapping.erl
+++ b/plugins_src/autouv/auv_mapping.erl
@@ -611,13 +611,16 @@ lsq_init_fs([F|Fs],P,We = #we{vp=Vtab},Ds0,N,Re0,Im0) ->
 	project_tri(array:get(A0,Vtab),array:get(B0,Vtab),
 		    array:get(C0,Vtab)), 
     %% Raimos old solution. 
-    SqrtDT = try math:sqrt(abs((X2-X1)*(Y3-Y1)-(Y2-Y1)*(X3-X1))) 
+    SqrtDT0 = try math:sqrt(abs((X2-X1)*(Y3-Y1)-(Y2-Y1)*(X3-X1)))
 	     catch _:_ -> 0.000001
 	     end,
+    SqrtDT = if SqrtDT0 =:= 0.0 -> 1.0;  % this can happen e.g. in a bevel/extrude without offset
+        true -> SqrtDT0
+    end,
     W1re = X3-X2, W1im = Y3-Y2, 
     W2re = X1-X3, W2im = Y1-Y3, 
     W3re = X2-X1, W3im = Y2-Y1,
-    
+
     Re=[[{A,W1re/SqrtDT},{B,W2re/SqrtDT},{C,W3re/SqrtDT}]|Re0],
     Im=[[{A,W1im/SqrtDT},{B,W2im/SqrtDT},{C,W3im/SqrtDT}]|Im0],
 

--- a/plugins_src/autouv/auv_seg_ui.erl
+++ b/plugins_src/autouv/auv_seg_ui.erl
@@ -278,13 +278,13 @@ seg_command(select_hard_edges, #seg{st=St0}=Ss) ->
 	#st{}=St -> get_seg_event(Ss#seg{st=St})
     end;
 seg_command({select,Mat}, #seg{st=St0}=Ss) ->
-    St = wings_material:command({select,[atom_to_list(Mat)]}, St0),
+    {save_state,St} = wings_material:command({select,[atom_to_list(Mat),select]}, St0),
     get_seg_event(Ss#seg{st=St});
 seg_command({segment,Type}, #seg{st=St0}=Ss) ->
     St = segment(Type, St0),
     get_seg_event(Ss#seg{st=St});
 seg_command({debug,Cmd}, Ss) ->
-    seg_command_debug(Cmd, Ss);
+    seg_command_debug({debug,Cmd}, Ss);
 seg_command(ignore_faces,#seg{st=St0,fs=Mode0}=Ss) ->    
     HiddenFs = wpa:sel_fold(fun(Fs,_,Acc) -> gb_sets:union(Fs,Acc) end,
 			    gb_sets:empty(), St0),

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -666,6 +666,7 @@ is_ascii_clean(T) when is_tuple(T) ->
     is_tuple_ascii_clean(1, tuple_size(T), T);
 is_ascii_clean(Num) when is_number(Num) -> true;
 is_ascii_clean(Atom) when is_atom(Atom) -> true;
+is_ascii_clean(Fun) when is_function(Fun) -> true;
 is_ascii_clean(_) -> false.
 
 is_tuple_ascii_clean(I, N, T) when I =< N ->


### PR DESCRIPTION
NOTE:
- Fixed a bug which was not enabling users to bind a hotkey to Lift Reported by ptoing. [Micheus]
- In AutoUV Segmenting the Select chart and the Unfold command (when faces have a zero width/height) were crashing Wings3D. [Micheus]