### PR TITLE
Implemented the help context button for dialogs

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -17,7 +17,7 @@
 -export([init/0,
 	 info/3,
 	 ask/3, ask/4, ask/5,
-	 dialog/3, dialog/4,
+	 dialog/3, dialog/4, dialog/5,
 	 ask_preview/5, dialog_preview/5
 	]).
 
@@ -225,29 +225,35 @@ ask_preview(Cmd, Bool, Title, Qs, St) ->
     ask(Bool, Title, preview, Qs, preview_fun(Cmd, St)).
 
 dialog_preview(Cmd, Bool, Title, Qs, St) ->
-    dialog(Bool, Title, preview, Qs, preview_fun(Cmd, St)).
+    dialog_1(Bool, Title, preview, Qs, preview_fun(Cmd, St)).
 
 %% Currently a modal dialog
 %%   (orginal wings let camera events trough)
 ask(Title, Qs0, Fun) ->
     {PreviewCmd, Qs} = preview_cmd(Qs0),
-    dialog(true, Title, PreviewCmd, queries(Qs), Fun).
+    dialog_1(true, Title, PreviewCmd, queries(Qs), Fun).
 ask(Ask, Title, Qs0, Fun) ->
     {PreviewCmd, Qs} = preview_cmd(Qs0),
-    dialog(Ask, Title, PreviewCmd, queries(Qs), Fun).
+    dialog_1(Ask, Title, PreviewCmd, queries(Qs), Fun).
 ask(Ask, Title, PreviewCmd, Qs, Fun) ->
-    dialog(Ask, Title, PreviewCmd, queries(Qs), Fun).
+    dialog_1(Ask, Title, PreviewCmd, queries(Qs), Fun).
 
 dialog(Title, Qs0, Fun) ->
     {PreviewCmd, Qs} = preview_cmd(Qs0),
-    dialog(true, Title, PreviewCmd, Qs, Fun).
+    dialog_1(true, Title, PreviewCmd, Qs, Fun).
+dialog(Title, Qs0, Fun, HelpFun) when is_list(Title)  ->
+    {PreviewCmd, Qs} = preview_cmd(Qs0),
+    dialog_1(true, Title, PreviewCmd, Qs, Fun, HelpFun);
 dialog(Ask, Title, Qs0, Fun) ->
     {PreviewCmd, Qs} = preview_cmd(Qs0),
-    dialog(Ask, Title, PreviewCmd, Qs, Fun).
-dialog(Ask, Title, PreviewCmd, Qs0, Fun) when is_list(Qs0) ->
+    dialog_1(Ask, Title, PreviewCmd, Qs, Fun).
+dialog(Ask, Title, Qs0, Fun, HelpFun) ->
+    {PreviewCmd, Qs} = preview_cmd(Qs0),
+    dialog_1(Ask, Title, PreviewCmd, Qs, Fun, HelpFun).
+dialog_1(Ask, Title, PreviewCmd, Qs0, Fun) when is_list(Qs0) ->
     Qs = {vframe_dialog, Qs0, [{buttons, [ok, cancel]}]},
-    dialog(Ask, Title, PreviewCmd, Qs, Fun);
-dialog(Ask, Title, PreviewCmd, Qs, Fun) when not is_list(Qs) ->
+    dialog_1(Ask, Title, PreviewCmd, Qs, Fun);
+dialog_1(Ask, Title, PreviewCmd, Qs, Fun) when not is_list(Qs) ->
     case element(1,Qs) of
 	preview -> error(Qs);
 	drag_preview_cmd -> error(Qs);
@@ -256,6 +262,9 @@ dialog(Ask, Title, PreviewCmd, Qs, Fun) when not is_list(Qs) ->
     {Dialog, Fields} = build_dialog(Ask andalso PreviewCmd, Title, Qs),
     %% io:format("Enter Dialog ~p ~p ~p~n",[Ask,PreviewCmd, Fields]),
     enter_dialog(Ask, PreviewCmd, Dialog, Fields, Fun).
+dialog_1(Ask, Title, PreviewCmd, Qs0, Fun, HelpFun) when is_list(Qs0) ->
+    Qs = {vframe_dialog, Qs0, [{buttons, [ok, cancel]},{help, HelpFun}]},
+    dialog_1(Ask, Title, PreviewCmd, Qs, Fun).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -760,6 +769,7 @@ build(Ask, Qs, Parent, Sizer) ->
 build(Ask, {vframe_dialog, Qs, Flags}, Parent, Sizer, []) ->
     Def = proplists:get_value(value, Flags, ?wxID_OK),
     Buttons = proplists:get_value(buttons, Flags, [ok, cancel]),
+    HelpFun = proplists:get_value(help, Flags, undefined),
     ButtMask = lists:foldl(fun(ok, Butts)     -> ?wxOK bor Butts;
 			      (cancel, Butts) -> ?wxCANCEL bor Butts;
 			      (yes, Butts)    -> ?wxYES bor Butts;
@@ -780,6 +790,19 @@ build(Ask, {vframe_dialog, Qs, Flags}, Parent, Sizer, []) ->
 			 _ ->
 			     ignore %% Preview connects it self
 		     end,
+		     case HelpFun of
+                         HelpFun when is_function(HelpFun)->
+			     {Title,Content} = HelpFun(),
+			     BtnHelp = wxButton:new(Dialog,?wxID_HELP, [{pos,{0,-1}}]),
+			     wxSizer:insert(Ok, 0, BtnHelp, [{proportion, 0}, {flag, ?wxLEFT}]),
+			     Help = fun(#wx{},_) ->
+                                 info(Title,Content, [{top_frame, Dialog}])
+			     end,
+			     wxDialog:connect(Dialog, command_button_clicked,
+			                      [{id, ?wxID_HELP}, {callback,Help}]);
+		         _ -> ignore
+		     end,
+
 		     Ok
 	     end,
     In = build(Ask, {vframe, Qs}, Parent, Sizer, []),

--- a/src/wpa.erl
+++ b/src/wpa.erl
@@ -14,7 +14,7 @@
 %%       from the wings core modules.
 
 -module(wpa).
--export([ask/3,ask/4,dialog/3,dialog/4,error_msg/1,error_msg/2,
+-export([ask/3,ask/4,dialog/3,dialog/4,dialog/5,error_msg/1,error_msg/2,
 	 yes_no/2,yes_no/3,yes_no_cancel/3,
 	 bind_unicode/2,bind_virtual/3,
 	 import/2,import/3,import_filename/2,
@@ -71,8 +71,14 @@ ask(Bool, Title, Qs, Fun) ->
 dialog(Title, Qs, Fun) ->
     wings_dialog:dialog(Title, Qs, Fun).
 
+dialog(Title, Qs, Fun, HelpFun) when is_list(Title) ->
+    wings_dialog:dialog(Title, Qs, Fun, HelpFun);
+
 dialog(Bool, Title, Qs, Fun) ->
     wings_dialog:dialog(Bool, Title, Qs, Fun).
+
+dialog(Bool, Title, Qs, Fun, HelpFun) ->
+    wings_dialog:dialog(Bool, Title, Qs, Fun, HelpFun).
 
 %% Show String in a dialog box.
 error_msg(String) ->


### PR DESCRIPTION
It was modified wings_dialog in order to enable us to add a help context
button to any dialog. It's placed in the same row as OK/Cancel buttons, but
in the left side of the dialog.
The Yafaray changes were made to uses this new resource.

NOTE:
- Added help content to Yafaray Export dialog. by oort;
- Fixed Transparency Refraction option in the Yafaray plugin. by oort;