### PR TITLE
 size bodies to specific volume

### DIFF
--- a/src/wings_body.erl
+++ b/src/wings_body.erl
@@ -29,6 +29,7 @@ menu(X, Y, St) ->
     Menu = [{?__(2,"Move"),{move,Dir}},
 	    wings_menu_util:rotate(St),
 	    wings_menu_util:scale(St),
+	    {?__(101,"Size To Volume"),fix_volume,?__(102,"Set intrinic sizes (volumes) of object(s)")},
 	    separator,
 	    {?__(3,"Flip..."),{flip,
 	       [{wings_s:dir(x),flip_fun(x),
@@ -150,6 +151,10 @@ arealight_conv(object, T) ->
       ?__(4,"Convert selected objects to area lights")}|T];
 arealight_conv(mixed, T) -> T.
 
+command(fix_volume, St) ->
+	wings_dialog:dialog(?__(1,"Set Volume"), fix_volume('Ask'), fun(Result) ->
+    	fix_volume(Result, St)
+    end);
 command({move,Type}, St) ->
     wings_move:setup(Type, St);
 command({rotate,Type}, St) ->
@@ -499,6 +504,21 @@ delete_object(Objects, #st{shapes=Shs0}=St) ->
 			gb_trees:delete(Id, Shs)
 		end, Shs0, Objects),
     wings_sel:valid_sel(St#st{shapes=Shs}).
+
+%%%
+%%% Fix (SET) Volume Command 
+%%%
+
+fix_volume(Asks) when is_atom(Asks) ->
+    [{text, 1.0, [{width,10},{key,volume}]}].
+fix_volume([{volume,Sz}], #st{}=St) ->
+    wings_sel:fold(
+        fun(_, #we{id=ID}=We, Acc) ->
+            WeNew = wings_we:set_volume(Sz, We),
+            wings_shape:replace(ID, WeNew, Acc)
+        end,
+        St, St).
+
 
 %%%
 %%% The Flip command

--- a/src/wings_we.erl
+++ b/src/wings_we.erl
@@ -26,6 +26,7 @@
 	 transform_vs/2,
 	 separate/1,
 	 normals/3,
+     set_volume/2,
 	 new_items_as_ordset/3,new_items_as_gbset/3,
 	 is_consistent/1,is_face_consistent/2,
 	 hide_faces/2,show_faces/1,num_hidden/1,
@@ -1262,3 +1263,19 @@ volume_1(Face, We) ->
     [V1,V2,V3] = wings_face:vertex_positions(Face, We),
     Bc = e3d_vec:cross(V2, V3),
     e3d_vec:dot(V1, Bc)/6.0.
+
+
+set_volume(Vol, #we{}=We) ->
+	{CX, CY, CZ} = wings_vertex:center(We),
+    set_volume(Vol, {CX,CY,CZ}, We).
+
+set_volume(Vol, {CX,CY,CZ}, #we{}=We) ->
+    VolCur = wings_we:volume(We),
+    Sz0 = math:pow(VolCur, 3.33333333e-1),
+    Sz1 = math:pow(Vol, 3.33333333e-1),
+    Sz = Sz1 / Sz0,
+    Scal = e3d_mat:scale(Sz, Sz, Sz),
+    Tr1 = e3d_mat:translate({-CX, -CY, -CZ}),
+    Tr2 = e3d_mat:translate({CX, CY, CZ}),
+    Mat = e3d_mat:mul([Tr1, Scal, Tr2]),
+    wings_we:transform_vs(Mat, We).


### PR DESCRIPTION
 Useful to fabricators and detail oriented modellers.

Plan is to create the counter-parts for sizing faces by area and also edges by length.  But wanted to proceesd one item type (body,face,edge)  at a time.  When all done ... I would re-factor the user interface part to a single file if one can be identified (wings_util) or similar. 
