### PR TITLE
 Allow Notebook items to scroll vertical

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -812,11 +812,14 @@ build(Ask, {vframe_dialog, Qs, Flags}, Parent, Sizer, []) ->
 
 build(Ask, {oframe, Tabs, Def, Flags}, Parent, WinSizer, In0)
   when Ask =/= false ->
+    DY  =  wxSystemSettings:getMetric(?wxSYS_SCREEN_Y)*5 div 6, %% don't take entire screen. 
     1 =:= Def orelse error({default, 1}),
     buttons =:= proplists:get_value(style, Flags, buttons) orelse error(Flags),
-    NB = wxNotebook:new(Parent, ?wxID_ANY, []),
+    NB = wxNotebook:new(Parent, ?wxID_ANY),
     AddPage = fun({Title, Data}, In) ->
-		      Panel = wxPanel:new(NB, []),
+              Panel = wxScrolledWindow:new(NB, []),
+              wxScrolledWindow:setScrollbars(Panel,-1,10,-1,10), % no horizontal
+              wxWindow:setMaxSize(Panel, {-1,DY}),
 		      case os:type() of
 			  {win32,_} ->
 			      BG = wxNotebook:getThemeBackgroundColour(NB),


### PR DESCRIPTION
Currently preferences and plugin-manager don't scroll when contents demand it.

Dan. I had to redo my pull request for stupid reasons. Anyways ... this one does contain the ideas from your previous discussion about dialogs.  And so long as the notebook pane content does not demand lots of window space ... you won't get a tall screen.  If you have many plugins installed ... the max limit will go into effect.  Testing proves this to be better than my original commit.