### PR TITLE
Fixes and additions I had made to 2.0.4

### DIFF
--- a/plugins_src/import_export/wpc_kerky.erl
+++ b/plugins_src/import_export/wpc_kerky.erl
@@ -223,7 +223,16 @@ pref_dialog(St) ->
 
 pref_result(Attr, St) ->
     set_user_prefs(Attr),
+    OldVal = get_var(renderer),
     init_pref(),
+    case get_var(renderer) of
+        OldVal -> ok;
+        false ->
+            wings_menu:update_menu(file, {render, ?TAG}, delete);
+        _ ->
+            [{Label, _}] = menu_entry(render),
+            wings_menu:update_menu(file, {render, ?TAG}, {append, -1, Label})
+    end,
     St.
 
 %%% Add necessary properties to lists, setup export function

--- a/plugins_src/import_export/wpc_pov.erl
+++ b/plugins_src/import_export/wpc_pov.erl
@@ -249,7 +249,16 @@ pref_dialog(St) ->
 
 pref_result(Attr, St) ->
     set_user_prefs(Attr),
+    OldVal = get_var(renderer),
     init_pref(),
+    case get_var(renderer) of
+        OldVal -> ok;
+        false ->
+            wings_menu:update_menu(file, {render, ?TAG}, delete);
+        _ ->
+            [{Label, _}] = menu_entry(render),
+            wings_menu:update_menu(file, {render, ?TAG}, {append, -1, Label})
+    end,
     St.
 
 %%% Add necessary properties to lists, setup export function

--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -2147,7 +2147,16 @@ pref_dialog(St) ->
 
 pref_result(Attr, St) ->
     set_user_prefs(Attr),
+    OldVal = get_var(renderer),
     init_pref(),
+    case get_var(renderer) of
+        OldVal -> ok;
+        false ->
+            wings_menu:update_menu(file, {render, ?TAG}, delete);
+        _ ->
+            [{Label, _}] = menu_entry(render),
+            wings_menu:update_menu(file, {render, ?TAG}, {append, -1, Label})
+    end,
     St.
 
 export_dialog(Op, Title) ->

--- a/src/wings_hotkey.erl
+++ b/src/wings_hotkey.erl
@@ -192,20 +192,19 @@ hotkey_key_message(Cmd) ->
 
 
 bind_from_event(Ev, Cmd) ->
-    Bkey0 = bindkey(Ev, Cmd),
-	Bkey = case Bkey0 of
-		{bindkey, _Key1} -> Bkey0;
-		{bindkey, _Mode, Key1} -> {bindkey, Key1}
-	end,
-	{bindkey, Key} = Bkey,
-	ets:insert(?KL, {Bkey,Cmd,user}),
+    Bkey = bindkey(Ev, Cmd),
+    Key = case Bkey of
+	    {bindkey, Key1} -> Key1;
+	    {bindkey, _Mode, Key1} -> Key1
+    end,
+    ets:insert(?KL, {Bkey,Cmd,user}),
     format_hotkey(Key, wx).
 
 
 unbind({Key}) ->
     unbind(Key);
 unbind(Key) ->
-    ets:delete(?KL, {bindkey, Key}).
+    ets:delete(?KL, Key).
 
 hotkeys_by_commands(Cs) ->
     hotkeys_by_commands_1(Cs, []).
@@ -221,7 +220,7 @@ hotkeys_by_commands_2([{Key0,Cmd,Src}|T]) ->
 	      {bindkey,Key1} -> Key1;
 	      {bindkey,_Mode,Key1} -> Key1
 	  end,
-    Info = {Key,format_hotkey(Key, wx),wings_util:stringify(Cmd),Src},
+    Info = {Key0,format_hotkey(Key, wx),wings_util:stringify(Cmd),Src},
     [Info|hotkeys_by_commands_2(T)];
 hotkeys_by_commands_2([]) -> [].
     

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -130,6 +130,11 @@ build_command(Name, Names, true) ->
 build_command(Name, Names, false) ->
     build_command(Name, Names).
 
+build_names(Term, Acc) when not is_tuple(Term) -> Acc;
+build_names({_,Term2}, Acc) when is_boolean(Term2) -> Acc;
+build_names({Term1,Term2}, Acc) ->
+    build_names(Term2, [Term1]++Acc).
+
 have_option_box(Ps) ->
     proplists:is_defined(option, Ps).
 
@@ -617,6 +622,49 @@ update_menu(file, Item = {recent_file, _}, delete, _) ->
     true = wxMenu:delete(File, Id),
     ets:delete(wings_menus, Id),
     ok;
+update_menu(Menu, Item, delete, _) ->
+    case menu_item_id(Menu, Item) of
+	false -> ok;
+	Id ->
+	    case ets:lookup(wings_menus, Id) of
+		[#menu{object=MenuItem}] ->
+		    ParentMenu = wxMenuItem:getMenu(MenuItem),
+		    true = wxMenu:delete(ParentMenu, Id),
+		    ets:delete(wings_menus, Id),
+		    ok;
+		_ ->
+		    ok
+	    end
+    end;
+update_menu(Menu, Item, {append, Pos0, Cmd0}, Help) ->
+    case menu_item_id(Menu, Item) of
+	false ->
+	    AddItem =
+		fun(SubMenu, Name) ->
+		    Pos =
+			if Pos0 >= 0 -> min(wxMenu:getMenuItemCount(SubMenu), Pos0);
+			true -> wxMenu:getMenuItemCount(SubMenu)
+			end,
+		    MO = wxMenu:insert(SubMenu, Pos, -1, [{text, Cmd0}]),
+		    Id = wxMenuItem:getId(MO),
+		    ME=#menu{name=Name, object=MO,
+			     wxid=Id, type=?wxITEM_NORMAL},
+		    true = ets:insert(wings_menus, ME),
+		    Cmd = setup_hotkey(MO, Cmd0),
+		    wxMenuItem:setText(MO, Cmd),
+		    is_list(Help) andalso wxMenuItem:setHelp(MO, Help)
+		end,
+
+	    Names = build_names(Item, [Menu]),
+	    case ets:match_object(wings_menus, #menu{name=Names, _ = '_'}) of
+		[#menu{object=SubMenu}] ->
+		    AddItem(SubMenu, build_command(Item, [Menu]));
+		_ ->
+		    io:format("update_menu: Item rejected (~p|~p)\n",[Menu,Item])
+	    end;
+	_ ->
+	    ok
+    end;
 update_menu(Menu, Item, Cmd0, Help) ->
     Id = menu_item_id(Menu, Item),
     MI = case ets:lookup(wings_menus, Id) of
@@ -849,7 +897,7 @@ menu_item_desc(Desc, HotKey) ->
 	_ -> Desc ++ "\t" ++ HotKey
     end.
 
-%% We want to use the prefdefined id where they exist (mac) needs for it's
+%% We want to use the predefined id where they exist (mac) needs for it's
 %% specialized menus but we want our shortcuts hmm.
 %% We also get little predefined icons for OS's that have that.
 predefined_item(Menu, Item, DefId) ->

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -143,6 +143,8 @@ have_magnet(_, true) -> activated;
 have_magnet(Ps, _) ->
     proplists:is_defined(magnet, Ps).
 
+item_checked(Ps) ->
+    proplists:get_value(crossmark, Ps).
 
 wx_popup_menu_init(Parent,GlobalPos,Names,Menus0) ->
     Owner = wings_wm:this(),
@@ -444,7 +446,15 @@ setup_popup([#menu{type=menu, wxid=Id, desc=Desc, help=Help, opts=Props, hk=HK}=
     Panel = wxPanel:new(Parent, [{winid, Id}]),
     setup_colors([Panel], Cs),
     Line  = wxBoxSizer:new(?wxHORIZONTAL),
-    wxSizer:addSpacer(Line, 3),
+    case item_checked(Props) of
+	true ->
+	    Checker = wxArtProvider:getBitmap("wxART_TICK_MARK",[{client, "wxART_MENU"}]),
+	    CBM = wxStaticBitmap:new(Panel, -1, Checker),
+	    wxSizer:add(Line, CBM, [{flag, ?wxALIGN_CENTER}]);
+	_ ->
+	    wxSizer:addSpacer(Line, 3)
+    end,
+
     wxSizer:add(Line, T1 = wxStaticText:new(Panel, Id, Desc),[{proportion, 0},{flag, ?wxALIGN_CENTER}]),
     wxSizer:setItemMinSize(Line, T1, Sz1, -1),
     wxSizer:addSpacer(Line, 10),


### PR DESCRIPTION
- Fixed a hotkey issue that was not enabling reassign a key;
- Made sure user cannot assign multiple hotkeys to the same command;
- Added the check marker to the popup menus;
- Implemented dynamic deletion and addition of items to menu;
- Added the logic of remove item from menu to Yafaray, POV-Ray and Kerkythea plugin.

OBS: Detailed description in the respective commits.