### PR TITLE
Eliminate crash in Ambient Occlusion

### DIFF
--- a/plugins_src/commands/ambocc_gl2.erl
+++ b/plugins_src/commands/ambocc_gl2.erl
@@ -17,7 +17,7 @@
 -include_lib("wings/src/wings.hrl").
 -include_lib("wings/e3d/e3d_image.hrl").
 
--record(ao, {df, vabs, fbo, tex, cleanup_fbo, buf}).
+-record(ao, {df, fbo, tex, cleanup_fbo, buf}).
 -define(TEX_SZ, 1024).
 -define(SAMPLE_SZ, 64).
 -define(NUM_SAMPLES, (?TEX_SZ div ?SAMPLE_SZ)).
@@ -27,8 +27,8 @@ ambient_occlusion(St) ->
     gl:pushAttrib(?GL_ALL_ATTRIB_BITS),
     setup_gl(),
     AO_0 = setup_shaders(),
-    {Vabs,DrawFun} = wpc_ambocc:make_disp_list(St),
-    AO = AO_0#ao{df=DrawFun,vabs=Vabs},
+    DrawFun = wpc_ambocc:make_disp_list(St),
+    AO = AO_0#ao{df=DrawFun},
     #st{shapes=Shapes} = St,
     ProcessObject = fun(_,We) -> process_obj(We,AO) end,
     Shapes2 = ?SLOW(gb_trees:map(ProcessObject, Shapes)),
@@ -60,8 +60,7 @@ setup_shaders() ->
     #ao{fbo=Fbo, tex=Tex, cleanup_fbo=Buffers,
 	buf = wings_io:get_buffer(?TEX_SZ*?TEX_SZ, ?GL_UNSIGNED_BYTE)}.
 
-cleanup(#ao{vabs=Vabs, cleanup_fbo=Fbo}) ->
-    _ = [wings_draw_setup:delete_vab(Vab) || Vab <- Vabs],
+cleanup(#ao{cleanup_fbo=Fbo}) ->
     wings_gl:delete_fbo(Fbo).
 
 process_obj(We, _) when ?IS_NOT_VISIBLE(We#we.perm) ->

--- a/plugins_src/commands/wpc_ambocc.erl
+++ b/plugins_src/commands/wpc_ambocc.erl
@@ -48,12 +48,11 @@ ambient_occlusion(St) ->
     StartTime = os:timestamp(),
     gl:pushAttrib(?GL_ALL_ATTRIB_BITS),
     setup_gl(),
-    {Vabs,DrawFun} = make_disp_list(St),
+    DrawFun = make_disp_list(St),
     #st{shapes=Shapes} = St,
     ProcessObject = fun(_, We) -> process_obj(We, DrawFun) end,
     Shapes2 = ?SLOW(gb_trees:map(ProcessObject, Shapes)),
     St2 = St#st{shapes=Shapes2},
-    _ = [wings_draw_setup:delete_vab(Vab) || Vab <- Vabs],
     gl:popAttrib(),
     EndTime = os:timestamp(),
     Seconds = timer:now_diff(EndTime,StartTime)/1.0e6,
@@ -97,7 +96,7 @@ make_disp_list(St) ->
 		   _ = [draw_vab(Vab) || Vab <- Vabs],
 		   ok
 	   end,
-    {Vabs,Draw}.
+    Draw.
 
 is_plain_geometry(#we{perm=P}=We) ->
     not (?IS_NOT_VISIBLE(P) orelse

--- a/src/wings_draw_setup.erl
+++ b/src/wings_draw_setup.erl
@@ -17,7 +17,6 @@
 
 -export([work/2,smooth/2,prepare/3,prepare/4,flat_faces/2]).
 -export([enable_pointers/2,disable_pointers/2]).
--export([delete_vab/1]).
 -export([face_vertex_count/1,has_active_color/1]).
 
 %% Used by wings_proxy.
@@ -177,11 +176,6 @@ face_vertex_count(#dlo{vab=#vab{mat_map=[{_Mat,_Type,Start,Count}|_]}}) ->
     Start+Count;
 face_vertex_count(#vab{mat_map=[{_Mat,_Type,Start,Count}|_]}) ->
     Start+Count.
-
-delete_vab(#vab{id=Vbo}) when is_integer(Vbo) ->
-    gl:deleteBuffers([Vbo]);
-delete_vab(#vab{}) ->
-    ok.
 
 %% Setup face_vs and face_fn and additional uv coords or vertex colors
 work(Dlo, St) ->


### PR DESCRIPTION
aa3007d189d7 added a double deallocation of VBOs. The VBOs in
question had been created by wings_draw_setup:we/3, which in turn
called wings_dl to save them in the garbage collected system
"display lists". Therefore, the Ambient Occlusion plug-in must
not try to delete the VBOs itself, since wings_dl will do
the deletion during its garbage collection.

wings_draw_setup:delete_vab/1 can be removed, since the Ambient
Occlusion plug-in was the last caller.

NOTE: Fixed the problem with crash in the Ambient Occlusion plug-in.