### PR TITLE
Fixed crash when mouse over 'Various Plane' dialog icon

### DIFF
--- a/plugins_src/primitives/wpc_plane.erl
+++ b/plugins_src/primitives/wpc_plane.erl
@@ -32,7 +32,7 @@ parse([Elem|Rest], NewMenu, Found) ->
     parse(Rest, [Elem|NewMenu], Found).
 
 plane_menu() ->
-    {?__(1,"Various Planes"),plane,{?__(7,"Create a plane")},[option]}.
+    {?__(1,"Various Planes"),plane,?__(7,"Create a plane"),[option]}.
 
 command({shape,{plane,Ask}}, St) -> make_plane(Ask, St);
 command(_, _) -> next.


### PR DESCRIPTION
NOTE: Moving the mouse over 'Various Plans' dialog icon was causing Wings3d
crash. Thanks to tkbd.