### PR TITLE
Added processing feedback to gen_char_hrl script

### DIFF
--- a/intl_tools/gen_char_hrl
+++ b/intl_tools/gen_char_hrl
@@ -51,7 +51,6 @@ main([]) ->
     end.
 
 scan([Lang|Langs], Dir, Acc) ->
-    io:format("Parsing language: ~ts\n",[Lang]),
     Res = filelib:fold_files(Dir, ".*" ++ Lang ++ ".lang$", true, fun handle/2, Acc),
     scan(Langs, Dir, Res);
 scan([], _, Acc) -> 
@@ -104,9 +103,18 @@ list_regions(Rs, _Line, Fd) ->
     list_regions(Rs, 0, Fd).
 
 handle(File, Acc) ->
-    io:format(" => ~ts\n",[File]),
-    {ok, Data} = file:consult(File),
-    lists:foldl(fun parse_data/2, Acc, Data).
+    try
+        {ok, Data} = file:consult(File),
+        lists:foldl(fun parse_data/2, Acc, Data)
+   catch error:Reason ->
+        io:format("Failed to parse the language file:\n ~ts\n", [File]),
+        case Reason of
+            {badmatch,{error,{Line,erl_parse,Msg}}} ->
+                io:format(" Msg: ~p\n Tip: Check line prior to ~w\n", [lists:flatten(Msg), Line]);
+            _ -> ok
+        end,
+        erlang:error(Reason)
+    end.
 
 parse_data({Atom, Data}, Acc) when is_atom(Atom) ->
     parse_data(Data, Acc);

--- a/intl_tools/gen_char_hrl
+++ b/intl_tools/gen_char_hrl
@@ -51,6 +51,7 @@ main([]) ->
     end.
 
 scan([Lang|Langs], Dir, Acc) ->
+    io:format("Parsing language: ~ts\n",[Lang]),
     Res = filelib:fold_files(Dir, ".*" ++ Lang ++ ".lang$", true, fun handle/2, Acc),
     scan(Langs, Dir, Res);
 scan([], _, Acc) -> 
@@ -103,6 +104,7 @@ list_regions(Rs, _Line, Fd) ->
     list_regions(Rs, 0, Fd).
 
 handle(File, Acc) ->
+    io:format(" => ~ts\n",[File]),
     {ok, Data} = file:consult(File),
     lists:foldl(fun parse_data/2, Acc, Data).
 


### PR DESCRIPTION
When a language file is updated and something is wrong/missed it's hard to
find which file is causing the problem. We can only know in which line the
problem is, but not the file name. This updates try to make this task easier
allowing us to know which was the last file processed when the crash happened.