### PR TITLE
That is a suggestion to fix the layout issue.

### DIFF
--- a/src/wings.erl
+++ b/src/wings.erl
@@ -1554,6 +1554,8 @@ drop_command(cancel_drop, St) -> St.
 %%%
 
 save_windows() ->
+    TopSize = wxWindow:getSize(?GET(top_frame)),
+    wings_pref:set_value(window_size, TopSize),
     {Contained, Free} = wings_frame:export_layout(),
     wings_pref:set_value(saved_windows, Free),
     wings_pref:set_value(saved_cont_windows, Contained).


### PR DESCRIPTION
By tracking the code it was not possible to find a way the splitters be
arranged in the saved location. The way the windows are created doesn't
allow us to do that. So, as an alternative, after all the windows has been
created and arranged in the proper layout we call a new function that set
the splitter position correctly.

It was also include a few lines to save the window size that is of interest
of us to be restored next time Wings3d is started. It's preserve its old
location is also desired, but not included in this branch.