### PR TITLE
Added preview resource to Camera dialog

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -1182,6 +1182,8 @@ build(Ask, {menu, Entries, Def, Flags}, Parent, Sizer, In) ->
 		lists:foldl(fun(Choice,N) -> setup_choices(Choice, Ctrl, Def, N) end, 0, Entries),
 		tooltip(Ctrl, Flags),
 		add_sizer(choice, Sizer, Ctrl, Flags),
+		Callback = {callback, notify_event_handler_cb(Ask, preview)},
+		wxCheckBox:connect(Ctrl, command_choice_selected, [Callback]),
 		Ctrl
 	end,
     [#in{key=proplists:get_value(key,Flags), def=Def, hook=proplists:get_value(hook, Flags),

--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -185,6 +185,7 @@ window_prop({plugin, _}=Name) ->
 window_prop(_) -> [].
 
 save_geom_props({show_axes,_}=P, Acc) -> [P|Acc];
+save_geom_props({show_cam_imageplane,_}=P, Acc) -> [P|Acc];
 save_geom_props({show_groundplane,_}=P, Acc) -> [P|Acc];
 save_geom_props({show_info_text,_}=P, Acc) -> [P|Acc];
 save_geom_props({current_view,View}, Acc) ->

--- a/src/wings_pref.erl
+++ b/src/wings_pref.erl
@@ -568,6 +568,7 @@ not_bad(workmode, _) -> false;
 not_bad(orthogonal_view, _) -> false;
 not_bad(show_memory_used, _) -> false;
 not_bad(show_axes, _) -> false;
+not_bad(show_cam_imageplane, _) -> false;
 not_bad(show_groundplane, _) -> false;
 not_bad(current_view, _) -> false;
 not_bad(camera_fov, _) -> false;


### PR DESCRIPTION
It was added preview capability to the Camera dialog. The Image Plane preview
is shown on the Geometry window as a blue border. It also can be activated by
enabling it using the proper option in View->Show menu.

Note: Added a Camera settings preview. Thanks tkbd for the suggestion.

![imageplanepreview](https://cloud.githubusercontent.com/assets/365243/18751177/70563d3e-80b4-11e6-905d-e39996d98aa9.png)