### PR TITLE
Fixed the not used statement pointed by dialyzer

### DIFF
--- a/plugins_src/import_export/wpc_kerky.erl
+++ b/plugins_src/import_export/wpc_kerky.erl
@@ -127,7 +127,6 @@ maybe_append(Condition, Menu, PluginMenu) ->
 is_plugin_active(Condition) ->
     case Condition of
         export -> get_var(dialogs);
-        edit -> get_var(dialogs);
         render -> get_var(renderer)
     end.
 
@@ -139,7 +138,7 @@ menu({file,export_selected}, Menu) ->
 menu({file,render}, Menu) ->
     maybe_append(render, Menu, menu_entry(render));
 menu({edit, plugin_preferences}, Menu) ->
-    Menu++menu_entry(pref);
+    Menu ++ menu_entry(pref);
 menu(_, Menu) ->
     Menu.
 

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -378,8 +378,8 @@ camera(St) ->
 				      {zoom_slider, pget(zoom_slider, Props)},
 				      {negative_format,{NegH,NegW}}], Sto),
 			    Keys = [negative_height, negative_width],
-			    wings_dialog:enable(Keys, Val =:= custom, Sto),
-			    wings_dialog:enable(lens_type, Val =/= custom, Sto),
+			    wings_dialog:enable(Keys, false, Sto),
+			    wings_dialog:enable(lens_type, true, Sto),
 			    wings_wm:set_prop(Active, current_view, DefView);
 			_ ->
 			    Keys = [negative_height, negative_width],
@@ -550,15 +550,6 @@ camera_propconv_negative_format(Props) ->
     end.
 
 camera_lens_type({24,36}, LensLength) ->
-    case round(LensLength) of
-	24 -> wide_angle;
-	35 -> moderate_wide_angle;
-	50 -> standard;
-	85 -> short_tele;
-	135 -> tele;
-	_ -> custom
-    end;
-camera_lens_type(default, LensLength) ->
     case round(LensLength) of
 	24 -> wide_angle;
 	35 -> moderate_wide_angle;


### PR DESCRIPTION
Only the event: "The pattern 'edit' can never match the type 'render'" was
no fixed because it must be used but, for that, the wings_plugin module
needs a fix that will remove/add the menu items.
In the current implementation if we disable any render plugin and try to
access the Plugin Preferences dialog we get a crash.