### PR TITLE
Simplify the parse transform for internationalization

### DIFF
--- a/intl_tools/wings_intl.hrl
+++ b/intl_tools/wings_intl.hrl
@@ -13,4 +13,4 @@
 -compile({parse_transform,tools}).
 
 -define(STR(A,B,Str), wings_lang:str({?MODULE,A,B},Str)).
--define(__(Key,Str), wings_lang:str({?MODULE,Key},Str)).
+-define(__(Key,Str), wings_lang:str({?MODULE,?FUNCTION_NAME,Key},Str)).


### PR DESCRIPTION
It is no longer necessary for the parse transform to insert the
function name into the key tuple, because it can be handled by
the ?FUNCTION_NAME macro introduced in OTP 19. We will continue
to use the parse transform to check for errors (such as duplicated
keys), but it can be simplified.