### PR TITLE
Fix the crash when disabling a plugin which has a window docked

### DIFF
--- a/plugins_src/commands/wpc_sel_win.erl
+++ b/plugins_src/commands/wpc_sel_win.erl
@@ -12,7 +12,7 @@
 %%
 
 -module(wpc_sel_win).
--export([init/0,menu/2,command/2,win_data/1]).
+-export([init/0,menu/2,command/2,win_data/1,win_name/0]).
 -export([window/1,window/5]).
 
 -export([init/1,
@@ -62,6 +62,9 @@ command(_,_) ->
 %% custom data is used to store windows properties and custom data - it should be parsed in window/5
 win_data(?WIN_NAME) ->
     {?WIN_NAME, {right,[]}}.
+
+win_name() ->
+    ?WIN_NAME.
 
 window(St) ->
     case wings_wm:is_window(?WIN_NAME) of

--- a/plugins_src/commands/wpc_views_win.erl
+++ b/plugins_src/commands/wpc_views_win.erl
@@ -12,7 +12,7 @@
 %%
 
 -module(wpc_views_win).
--export([init/0,menu/2,command/2,win_data/1]).
+-export([init/0,menu/2,command/2,win_data/1,win_name/0]).
 -export([window/1,window/5]).
 
 -export([init/1,
@@ -58,6 +58,9 @@ command(_,_) ->
 %% custom data is used to store windows properties and custom data - it should be parsed in window/5
 win_data(?WIN_NAME=Name) ->
     {Name, {right,[]}}.
+
+win_name() ->
+    ?WIN_NAME.
 
 window(St) ->
     case wings_wm:is_window(?WIN_NAME) of

--- a/src/wings_plugin.erl
+++ b/src/wings_plugin.erl
@@ -390,6 +390,7 @@ manager_command({edit,plugin_manager}, St) ->
 		  Disabled = [M || {M,false} <- Res],
 		  ?SET(wings_plugins, Ps -- Disabled),
 		  update_menus(Cps, Disabled),
+		  plugin_close_win(Disabled),
 		  update_disabled(Disabled, St)
 	  end,
     Dialog = mk_dialog(Cps, false),
@@ -726,3 +727,27 @@ restore_window(M, WinName, Pos, Size, CtmData, St) ->
 module_found(M,[M|_]) -> true;
 module_found(M,[_|T]) -> module_found(M,T);
 module_found(_,[]) -> false.
+
+
+%%%
+%%% Plugin Close Windows Utility
+%%%
+
+% It allows this module to close any plugin's window when a module is disabled.
+plugin_close_win([M|Ps]) ->
+    try M:win_name() of
+	WinName ->
+	    plugin_close_win_0(WinName),
+	    plugin_close_win(Ps)
+    catch
+    	_Exception:_Reason ->
+	    plugin_close_win(Ps)
+    end;
+plugin_close_win([]) -> none.
+
+plugin_close_win_0([]) -> ignore;
+plugin_close_win_0([Win|Wins]) ->
+    plugin_close_win_0(Win),
+    plugin_close_win_0(Wins);
+plugin_close_win_0(Win) ->
+    wings_frame:close(Win).


### PR DESCRIPTION
The issue was observed when disabling a plugin with window docked and after
left and start/restating Wings3D we got a hard crash that denied Wings3d to
be started. The way to fix that was only by editing the preferences.txt.