### PR TITLE
Mv/fixes v2.1.3 b

### DIFF
--- a/src/wings_geom_win.erl
+++ b/src/wings_geom_win.erl
@@ -638,9 +638,12 @@ update_folders({Curr, Fld0}, TC) ->
 		 Leaves = lists:map(Add, Sorted),
 		 wxTreeCtrl:expand(TC, Root),
 		 All = [{Root,?NO_FLD}|Leaves],
-		 {Node,_} = lists:keyfind(Curr, 2, All),
-		 wxTreeCtrl:selectItem(TC, Node),
-		 wxTreeCtrl:ensureVisible(TC, Node),
+		 case lists:keyfind(Curr, 2, All) of
+		     {Node,_} ->
+			 wxTreeCtrl:selectItem(TC, Node),
+			 wxTreeCtrl:ensureVisible(TC, Node);
+		     _ -> io:format("Unexpected folder error.\nCurr: ~p\nAll: ~p\n\n",[Curr,All])
+		 end,
 		 All
 	 end,
     wx:batch(Do).

--- a/src/wings_shape.erl
+++ b/src/wings_shape.erl
@@ -427,6 +427,8 @@ create_folder(Folder, #st{pst=Pst0}=St) ->
     Pst = gb_trees:update(?FOLDERS, {Folder,Fld}, Pst0),
     St#st{pst=Pst}.
 
+rename_folder(OldName, OldName, St) -> St;
+
 rename_folder(OldName, NewName, St0) ->
     #st{pst=Pst0}=St1 = create_folder(NewName, St0),
     {_,Fld0} = gb_trees:get(?FOLDERS, Pst0),


### PR DESCRIPTION
- Fixed wrong message when renaming folder is aborted;
- Workaround to avoid the Geometry Graph window closes unexpectedly.