### PR TITLE
Optimize wings_draw:split/3

### DIFF
--- a/src/wings_draw.erl
+++ b/src/wings_draw.erl
@@ -563,8 +563,7 @@ unlit_plain_face_1([], _, Bin) -> Bin.
 %%% Splitting of objects into two display lists.
 %%%
 
-split(#dlo{ns={Ns0},src_we=#we{fs=Ftab}}=D, Vs, St) ->
-    Ns = remove_stale_ns(Ns0, Ftab),
+split(#dlo{ns={Ns}}=D, Vs, St) ->
     split_1(D#dlo{ns=Ns}, Vs, St);
 split(D, Vs, St) -> split_1(D, Vs, St).
 
@@ -581,13 +580,14 @@ split_2(#dlo{mirror=M,src_sel=Sel,src_we=#we{fs=Ftab}=We,
     StaticVs = static_vs(Faces, Vs, We),
 
     VisFtab = wings_we:visible(gb_trees:to_list(Ftab), We),
-    {Work,#dlo{ns=Ns},FtabDyn} = split_faces(D, VisFtab, Faces, St),
+    {Work,#dlo{ns=Ns},FtabStatic,FtabDyn} =
+	split_faces(D, VisFtab, Faces, St),
 
     %% To support commands that create new objects with static
     %% geometry (such as Shell Extrude), we must be sure to pass
     %% on the new normals table or the static edges will not be
     %% visible.
-    StaticEdgeDl = make_static_edges(Faces, D#dlo{ns=Ns}),
+    StaticEdgeDl = make_static_edges(FtabStatic, D#dlo{ns=Ns}),
     {DynVs,VsDlist} = split_vs_dlist(Vs, StaticVs, Sel, We),
 
     WeDyn = wings_facemat:gc(We#we{fs=gb_trees:from_orddict(FtabDyn)}),
@@ -603,16 +603,6 @@ split_2(#dlo{mirror=M,src_sel=Sel,src_we=#we{fs=Ftab}=We,
 	 src_sel=Sel,src_we=WeDyn,split=Split,
 	 proxy=UsesProxy, proxy_data=Pd,
 	 needed=Needed,open=Open}.
-
-remove_stale_ns(none, _) -> none;
-remove_stale_ns(Ns, Ftab) ->
-    Deleted = array:default(Ns),
-    array:sparse_map(fun(Face, Term) ->
-			     case gb_trees:is_defined(Face, Ftab) of
-				 true  -> Term;
-				 false -> Deleted
-			     end
-		     end, Ns).
 
 static_vs(Fs, Vs, We) ->
     VsSet = gb_sets:from_ordset(Vs),
@@ -631,18 +621,17 @@ static_vs_1([], _, _, Acc) -> ordsets:from_list(Acc).
 split_faces(#dlo{needed=Need}=D0, Ftab0, Fs0, St) ->
     Ftab = sofs:from_external(Ftab0, [{face,data}]),
     Fs = sofs:from_external(Fs0, [face]),
+    {DynFtab0,StaticFtab0} = sofs:partition(1, Ftab, Fs),
+    DynFtab = sofs:to_external(DynFtab0),
+    StaticFtab = sofs:to_external(StaticFtab0),
     case member(work, Need) orelse member(smooth, Need) of
 	false ->
 	    %% This is wireframe mode. We don't need any
 	    %% 'work' display list for faces.
-	    FtabDyn = sofs:to_external(sofs:restriction(Ftab, Fs)),
-	    {none,D0,FtabDyn};
+	    {none,D0,StaticFtab,DynFtab};
 	true ->
 	    %% Faces needed. (Either workmode or smooth mode.)
-	    {FtabDyn0,StaticFtab0} = sofs:partition(1, Ftab, Fs),
-	    FtabDyn = sofs:to_external(FtabDyn0),
-	    StaticFtab = sofs:to_external(StaticFtab0),
-
+	    %%
 	    %% Make sure that every static face has an entry
 	    %% in the normals array. Most of the time, this is
 	    %% not needed because newly created faces are
@@ -654,7 +643,7 @@ split_faces(#dlo{needed=Need}=D0, Ftab0, Fs0, St) ->
 	    StaticPlan = wings_draw_setup:prepare(StaticFtab, D1, St),
 	    D = wings_draw_setup:flat_faces(StaticPlan, D1),
 	    Dl = draw_flat_faces(D, St),
-	    {[Dl],D1,FtabDyn}
+	    {[Dl],D1,StaticFtab,DynFtab}
     end.
 
 split_new_normals(Ftab, #dlo{ns=Ns0,src_we=We}=D) ->
@@ -678,22 +667,10 @@ split_new_normals([{Face,Edge}|T], We, Ns0) ->
     end;
 split_new_normals([], _, Ns) -> Ns.
 
-make_static_edges(DynFaces, #dlo{ns=none}) ->
-    make_static_edges_1(DynFaces, [], []);
-make_static_edges(DynFaces, #dlo{ns=Ns}) ->
-    make_static_edges_1(DynFaces, array:sparse_to_orddict(Ns), []).
-
-make_static_edges_1([F|Fs], [{F,_}|Ns], Acc) ->
-    make_static_edges_1(Fs, Ns, Acc);
-make_static_edges_1([_|_]=Fs, [{_,N}|Ns], Acc) ->
-    make_static_edges_1(Fs, Ns, [N|Acc]);
-make_static_edges_1(_, Ns, Acc) ->
-    make_static_edges_2(Ns, Acc).
-
-make_static_edges_2([{_,N}|Ns], Acc) ->
-    make_static_edges_2(Ns, [N|Acc]);
-make_static_edges_2([], Acc) ->
-    make_edge_dl(Acc).
+make_static_edges(_Ftab, #dlo{ns=none}) ->
+    make_edge_dl([]);
+make_static_edges(Ftab, #dlo{ns=Ns}) ->
+    make_edge_dl([array:get(F, Ns) || {F,_} <- Ftab]).
 
 insert_vtx_data([V|Vs], Vtab, Acc) ->
     insert_vtx_data(Vs, Vtab, [{V,array:get(V, Vtab)}|Acc]);


### PR DESCRIPTION
The remove_stale_ns/2 function called by wings_draw:split/3 is
quite expensive because it rebuilds the entire array. Most of the
time, all the work is wasted because there are no stale normals
to remove. The exception is the Intrude command.

remove_stale_ns/2 is needed for the Intrude command because
make_static_edges/2 is given a list a list of the dynamic faces and
assumes that any face that is not dynamic is static. If the stale
normals have not been removed, the edges for the deleted faces will be
shown when executing the Intrude command.

Fix this by letting split_faces/4 return the face tab for the static
faces. Given the static face tab, remove_stale_ns/2 is no longer
necessary and make_static_edges/2 can be drastically simplified.