### PR TITLE
Mv/fixes v2.1.4.1

### DIFF
--- a/plugins_src/commands/wpc_sculpt.erl
+++ b/plugins_src/commands/wpc_sculpt.erl
@@ -1090,10 +1090,9 @@ update_dlist({edge_info,EdgeInfo},#dlo{plugins=Pdl,src_we=#we{vp=Vtab}}=D, _) ->
 	    Str = wings_pref:get_value(sculpt_strength),
 	    ColFac = Str*10,		     % the range of 0..1
 	    ColFrom = col_to_vec(wings_pref:get_value(edge_color)),
-	    ColTo = {1.0*ColFac,0.0*ColFac,1.0}, % from blue to magenta
+	    ColTo = {1.0*ColFac,0.0,1.0}, % from blue to magenta
 	    ColRange = e3d_vec:sub(ColTo, ColFrom),
-	    Lines = prepare_edge_pump(EdgeInfo, Vtab, ColFrom,
-				      ColRange, <<>>),
+	    Lines = prepare_edge_pump(EdgeInfo, Vtab, ColFrom, ColRange, <<>>),
 	    Draw = draw_fun(Lines),
 	    D#dlo{plugins=[{Key,Draw}|Pdl]}
     end.
@@ -1101,7 +1100,9 @@ update_dlist({edge_info,EdgeInfo},#dlo{plugins=Pdl,src_we=#we{vp=Vtab}}=D, _) ->
 draw_fun(Data) ->
     N = byte_size(Data) div (4*3*4),
     F = fun() ->
-		gl:drawArrays(?GL_LINES, 0, N)
+		gl:depthFunc(?GL_LEQUAL),
+		gl:drawArrays(?GL_LINES, 0, N),
+		gl:depthFunc(?GL_LESS)
 	end,
     wings_vbo:new(F, Data, [vertex,color]).
 

--- a/plugins_src/wp9_dialogs.erl
+++ b/plugins_src/wp9_dialogs.erl
@@ -53,13 +53,13 @@ file_dialog(Type, Prop, Title, Cont) ->
         ?wxID_OK ->
             Dir = wxFileDialog:getDirectory(Dlg),
             File = if Multiple =:= true ->
-                           wxFileDialog:getFilenames(Dlg);
+                           wxFileDialog:getPaths(Dlg);
                       true ->
-                           wxFileDialog:getFilename(Dlg)
+                           wxFileDialog:getPath(Dlg)
                    end,
             wxDialog:destroy(Dlg),
             if Multiple =:= true ->
-                    [wings_wm:psend(Cont(filename:join(Dir, File0)),wings_wm:get_current_state()) || File0 <- File],
+                    [Cont(filename:join(Dir, File0)) || File0 <- File],
                     keep;
                true ->
                     Cont(filename:join(Dir, File))

--- a/src/wings_develop.erl
+++ b/src/wings_develop.erl
@@ -39,7 +39,6 @@ menu() ->
      {"Print Scene Size",print_scene_size,
       "Print the scene size to the console"},
      separator,
-     {"Loaded Font Glyphs",font_libs},
      {"Show Cursor",show_cursor,
       "Unhide the cursor in case of a crash and it disappears"}].
 
@@ -61,11 +60,6 @@ command(print_scene_size, St) ->
     Words = erts_debug:size(St),
     io:format("The current scene is using ~p words\n", [Words]),
     keep;
-command(font_libs, _) ->
-    Sf = length(ets:tab2list(system_font)),
-    Cf = length(ets:tab2list(console_font)),
-    Str =io_lib:format("system_font glyphs loaded: ~p\n console_font glyphs loaded: ~p\n",[Sf,Cf]),
-    wings_u:message(Str);
 command(show_cursor, _) ->
     case wings_io:is_grabbed() of
 	true  -> wings_io:reset_grab();

--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -2423,6 +2423,7 @@ edge_fun(EdList, ClBin, Vtab) ->
     gl:bindBuffer(?GL_ARRAY_BUFFER, 0),
     N = byte_size(EdBin) div 12,
     D = fun() ->
+		gl:depthFunc(?GL_LEQUAL),
 		gl:bindBuffer(?GL_ARRAY_BUFFER, VboEs),
 		gl:vertexPointer(3, ?GL_FLOAT, 0, 0),
 		gl:bindBuffer(?GL_ARRAY_BUFFER, VboCl),
@@ -2432,7 +2433,8 @@ edge_fun(EdList, ClBin, Vtab) ->
 		gl:enableClientState(?GL_VERTEX_ARRAY),
 		gl:drawArrays(?GL_LINES, 0, N),
 		gl:disableClientState(?GL_VERTEX_ARRAY),
-		gl:disableClientState(?GL_COLOR_ARRAY)
+		gl:disableClientState(?GL_COLOR_ARRAY),
+		gl:depthFunc(?GL_LESS)
 	end,
     {call,D,[{vbo,VboEs},{vbo,VboCl}]}.
 


### PR DESCRIPTION
- With Develop menu enabled 'Loaded Font Glyphs' cases a crash
- Fixed the visualization of magnet influence in Tweak mode and for Sculpt too;
- Workaround to avoid load fail from memory stick drivers;
- Fixed ps/eps importer crashes for invalid file.