### PR TITLE
Fixed crash caused by wrong parameter type in Rotate->Region

### DIFF
--- a/plugins_src/commands/wpc_region.erl
+++ b/plugins_src/commands/wpc_region.erl
@@ -147,7 +147,7 @@ rotate_region(OuterVs, Faces, We, Acc) ->
     [{Vs,rotate_fun(Center, VsPos, PlaneNormal)}|Acc].
 
 rotate_fun(Center, VsPos, Axis) ->
-    fun(Angle, A) ->
+    fun([Angle], A) ->
 	    rotate(Center, Axis, Angle, VsPos, A)
     end.
 


### PR DESCRIPTION
Apparently this bug kept hidden since the wings_drag code review.