### PR TITLE
Fixes for 2.1.5 (b)

### DIFF
--- a/e3d/e3d_obj.erl
+++ b/e3d/e3d_obj.erl
@@ -410,7 +410,13 @@ skip_blanks(S) -> S.
 
 read_open(Name) ->
     case file:open(Name, [binary,read,raw]) of
-	{ok,Fd} -> {ok,{Fd,<<>>}};
+	{ok,Fd} ->
+	    {ok,Bin} = file:read(Fd,4),
+	    %% provisionally remove the BOM mark if present. The code needs to be
+	    %% rewritten to manage unicode files
+	    {_,Bytes} = unicode:bom_to_encoding(Bin),
+	    file:position(Fd,Bytes),
+	    {ok,{Fd,<<>>}};
 	{error,_}=Error -> Error
     end.
 

--- a/plugins_src/autouv/shaders/Makefile
+++ b/plugins_src/autouv/shaders/Makefile
@@ -38,8 +38,8 @@ FILES = standard.vs \
 	lava.fs \
 	wpc_caustics.auv \
 	caustics.fs \
-	wpc_camuflage.auv \
-	camuflage.fs \
+	wpc_camouflage.auv \
+	camouflage.fs \
 	README-shaders.txt
 
 

--- a/plugins_src/autouv/shaders/camouflage.fs
+++ b/plugins_src/autouv/shaders/camouflage.fs
@@ -1,5 +1,5 @@
 //
-//  camuflage.fs --
+//  camouflage.fs --
 //
 //     Camuflage 3D shader based on three 2D I found at GLSL SandBox:
 //     - Checker: http://glslsandbox.com/e#23824.0
@@ -11,7 +11,7 @@
 //  See the file "license.terms" for information on usage and redistribution
 //  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
 //
-//     $Id: camuflage.fs,v 1.0 2015/12/02 21:40:0 micheus Exp $
+//     $Id: camouflage.fs,v 1.0 2015/12/02 21:40:0 micheus Exp $
 //
 
 uniform int type;

--- a/plugins_src/autouv/shaders/wpc_camouflage.auv
+++ b/plugins_src/autouv/shaders/wpc_camouflage.auv
@@ -1,21 +1,21 @@
 %%
-%%  wpc_camuflage.auv --
+%%  wpc_camouflage.auv --
 %%
-%%     Config file for camuflage shaders
+%%     Config file for camouflage shaders
 %%
 %%  Copyright (c) 2015 Micheus
 %%
 %%  See the file "license.terms" for information on usage and redistribution
 %%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
 %%
-%%     $Id: wpc_camuflage.auv,v 1.0 2015/12/02 21:40:0 micheus Exp $
+%%     $Id: wpc_camouflage.auv,v 1.0 2015/12/02 21:40:0 micheus Exp $
 %%
 
 %%  Everything behind a '%' is a comment
 
-{name, "Camuflage"}.                % The name in the shader selector
+{name, "Camouflage"}.               % The name in the shader selector
 {vertex_shader, "standard.vs"}.     % Vertex shader used
-{fragment_shader, "camuflage.fs"}.  % Fragment shader used
+{fragment_shader, "camouflage.fs"}. % Fragment shader used
 {auv, auv_bbpos3d}.                 % Use bounding box for positions
 %% Uses these uniforms:
 %% {uniform, Type, VarID in shader, DefaultValue, StringInGUI}

--- a/plugins_src/autouv/wpc_snap_win.erl
+++ b/plugins_src/autouv/wpc_snap_win.erl
@@ -30,7 +30,7 @@
 	 handle_call/3, handle_cast/2, handle_event/2,
 	 handle_info/2, code_change/3, terminate/2]).
 
--record(s, {reply,name,w,h,opacity=0.5,sx=1.0,sy=1.0,tx=0.0,ty=0.0,r=0.0}).
+-record(s, {active=false,reply,name,w,h,opacity=0.5,sx=1.0,sy=1.0,tx=0.0,ty=0.0,r=0.0,tiled=1}).
 
 init() -> true.
 
@@ -43,11 +43,11 @@ snap_win_menu() ->
      ?__(2,"Shows the snap image window")}.
 
 proportional_scale() ->
-    [{?__(1,"...to Current X"),proportional_x,
+    [{?__(1,"...to Current X"),{auv_snap_prop,proportional_x},
       ?__(2,"Scale image's Y value to be proportional to it's current X value")},
-     {?__(3,"...to Current Y"),proportional_y,
+     {?__(3,"...to Current Y"),{auv_snap_prop,proportional_y},
       ?__(4,"Scale image's X value to be proportional to it's current Y value")},
-     {?__(5,"Actual Size"),actual_size,
+     {?__(5,"Actual Size"),{auv_snap_prop,actual_size},
       ?__(6,"Reset image to its actual size")}].
 
 snap_menu(scale) ->
@@ -55,7 +55,7 @@ snap_menu(scale) ->
      {?__(3,"Vertical"),{auv_snap_scale,y},?__(4,"Scale the background image vertically")},
      {?__(5,"Free"),{auv_snap_scale,free},?__(6,"Scale the background image freely")},
      {?__(7,"Uniform"),{auv_snap_scale,uniform},?__(8,"Scale the background image uniformly")},
-     {?__(32,"Proportional"),{auv_snap_prop,proportional_scale()},?__(33,"Make image scale proportional")}];
+     {?__(32,"Proportional"),{auv_snap_scale,proportional_scale()},?__(33,"Make image scale proportional")}];
 snap_menu(move) ->
     [{?__(1,"Horizontal"),{auv_snap_move,x},?__(10,"Move the background image horizontally")},
      {?__(3,"Vertical"),{auv_snap_move,y}, ?__(12,"Move the background image vertically")},
@@ -81,6 +81,8 @@ command({snap_image,cancel}, St) ->
     cancel(St);
 command({snap_image,{opacity,Opacity}}, St) ->
     opacity(Opacity, St);
+command({snap_image,{tiled,Active}}, St) ->
+    tiled(Active, St);
 command({snap_image,apply}, St) ->
     snap(St);
 command({_,{auv_snap_scale,Op}}, St) ->
@@ -91,11 +93,14 @@ command({_,{auv_snap_fit,Op}}, St) ->
     fit(Op,St);
 command({snap_image,{rotate,Rotate}}, St) ->
     rotate(Rotate, St);
-command(_, _) ->
+command(_Op, _) ->
     next.
 
 active() ->
-    get(?MODULE) =/= undefined.
+    case get(?MODULE) of
+	undefined -> false;
+	#s{active=Active} -> Active
+    end.
 
 start(St0) ->
     #s{reply=ImgId} = get(?MODULE),
@@ -105,13 +110,20 @@ start(St0) ->
     St0.
 
 start(#{reply:=ImgId,name:=Name,w:=W,h:=H}, St) ->
-    cancel(),
-    put(?MODULE, #s{reply=ImgId,name=Name,w=W,h=H}),
+    State =
+	case get(?MODULE) of
+	    undefined -> #s{active=true,reply=ImgId,name=Name,w=W,h=H};
+	    State0 -> State0#s{active=true,reply=ImgId,name=Name,w=W,h=H}
+	end,
+    put(?MODULE, State),
     start(St).
 
 cancel() ->
-    wings:unregister_postdraw_hook(geom, ?MODULE),
-    erase(?MODULE).
+    case get(?MODULE) of
+	undefined -> ignore;
+	State -> put(?MODULE, State#s{active=false})
+    end,
+    wings:unregister_postdraw_hook(geom, ?MODULE).
 
 cancel(St) ->
     cancel(),
@@ -201,6 +213,12 @@ opacity(Opacity, St) ->
     put(?MODULE, State#s{opacity=Opacity}),
     St.
 
+tiled(Active, St) ->
+    State=get(?MODULE),
+    wings_pref:set_value(snap_tiled, Active),
+    put(?MODULE, State#s{tiled=Active}),
+    St.
+
 draw_image(Image,_St) ->
     gl:pushAttrib(?GL_ALL_ATTRIB_BITS),
     gl:matrixMode(?GL_PROJECTION),
@@ -217,9 +235,18 @@ draw_image(Image,_St) ->
     gl:blendFunc(?GL_SRC_ALPHA, ?GL_ONE_MINUS_SRC_ALPHA),
     gl:enable(?GL_TEXTURE_2D),
     gl:bindTexture(?GL_TEXTURE_2D, Image),
+
+    #s{w=IW,h=IH,sx=Sx,sy=Sy,tx=Tx,ty=Ty,r=Rot,opacity=Opa,tiled=Tiled} = get(?MODULE),
+    if Tiled =:= 0 ->
+	gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_S, ?GL_CLAMP_TO_BORDER),
+	gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_T, ?GL_CLAMP_TO_BORDER);
+    true ->
+	gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_S, ?GL_REPEAT),
+	gl:texParameteri(?GL_TEXTURE_2D, ?GL_TEXTURE_WRAP_T, ?GL_REPEAT)
+    end,
+
     gl:texEnvi(?GL_TEXTURE_ENV, ?GL_TEXTURE_ENV_MODE, ?GL_MODULATE),
 
-    #s{w=IW,h=IH,sx=Sx,sy=Sy,tx=Tx,ty=Ty,r=Rot,opacity=Opa} = get(?MODULE),
     gl:color4f(1.0, 1.0, 1.0, Opa),   %%Semitransparant
     {_,_,W,H} = wings_wm:viewport(),
     {Xs,Ys,Xe,Ye} = {0.0,0.0,1.0,1.0},
@@ -262,14 +289,13 @@ calc_uv_fun() ->
     {MM,PM,{_,_,W,H}=Viewport} = wings_u:get_matrices(0, original),
     #s{w=IW,h=IH,sx=Sx,sy=Sy,tx=Tx,ty=Ty,r=Rot} = get(?MODULE),
     {Xs,Ys} = scale(W, H, IW, IH),
-
     %% In the fun, do the calculations that are specific
     %% for each vertex.
     fun({X,Y,Z}) ->
             {S,T,_} = wings_gl:project(X, Y, Z, MM, PM, Viewport),
             Center = 0.5,
             {XA0,YA0}={Tx/2+(S/W*Xs*Sx+Center-Sx*Xs/2),Ty/2+(T/H*Sy*Ys+Center-Sy*Ys/2)},
-            {XA,YA}=rotate(Rot,{XA0-Center,YA0-Center}),
+            {XA,YA}=rotate_uv(Rot,{XA0-Center,YA0-Center}),
             {Center+XA,Center+YA}
     end.
 
@@ -432,7 +458,7 @@ forward_event(_, _Window, _St) ->
     keep.
 
 get_state(?WIN_NAME) ->
-    {wings_pref:get_value(snap_opacity, 0.5)}.
+    {wings_pref:get_value(snap_opacity, 0.5),wings_pref:get_value(snap_tiled, 1)}.
 
 snap_label(image) ->
     ?__(1, "Select Image");
@@ -451,7 +477,9 @@ snap_label(move) ->
 snap_label(scale) ->
     ?__(8, "Scale");
 snap_label(fit) ->
-    ?__(9, "Fit").
+    ?__(9, "Fit");
+snap_label(tiled) ->
+    ?__(10, "Tiled Image").
 
 mod_choices() ->
     [snap_label(move) ++ " ...",
@@ -476,7 +504,9 @@ snap_tooltip(move) ->
 snap_tooltip(scale) ->
     ?__(8, "Scale the background image");
 snap_tooltip(fit) ->
-    ?__(9, "Fit image to the dimensions of the viewport").
+    ?__(9, "Fit image to the dimensions of the viewport");
+snap_tooltip(tiled) ->
+    ?__(10, "Draws the image repeatedly ").
 
 append_value(Op=opacity, Val) ->
     snap_label(Op) ++ " (" ++ to_str(Val) ++ "%)";
@@ -492,7 +522,7 @@ to_str(Val) ->
 
 -record(state, {me, name, shown, state, cols, ctrls}).
 
-init([Frame, Name, {OpaVal}=State]) ->
+init([Frame, Name, {OpaVal,Tiled}=State]) ->
     #{bg:=BG, text:=_FG} = Cols = wings_frame:get_colors(),
     Panel = wxPanel:new(Frame, [{style, ?wxNO_BORDER}, {size,{200,300}}]),
     wxPanel:setFont(Panel, ?GET(system_font_wx)),
@@ -517,6 +547,9 @@ init([Frame, Name, {OpaVal}=State]) ->
     %% second level (Panel content): Snap Image, Opacity, Rotation
     BSnap = wxButton:new(CtrlBox, ?wxID_ANY, [{label,snap_label(snap)}]),
     wxWindow:setToolTip(BSnap, wxToolTip:new(snap_tooltip(snap))),
+    TileChk = wxCheckBox:new(CtrlBox, ?wxID_ANY, snap_label(tiled)),
+    wxCheckBox:setValue(TileChk,Tiled=:=1),
+    wxWindow:setToolTip(TileChk, wxToolTip:new(snap_tooltip(tiled))),
     OpaLbl = wxStaticText:new(CtrlBox, ?wxID_ANY, append_value(opacity,OpaVal*100.0)),
     Opa = wxSlider:new(CtrlBox, ?wxID_ANY, round(OpaVal*100.0), 0, 100),
     wxWindow:setToolTip(Opa, wxToolTip:new(snap_tooltip(opacity))),
@@ -528,6 +561,8 @@ init([Frame, Name, {OpaVal}=State]) ->
     %% layout settings for the second level controls
     Szr2 = wxBoxSizer:new(?wxVERTICAL),
     wxSizer:add(Szr2, BSnap, [{proportion, 0}, {border, 2}, {flag, ?wxEXPAND}]),
+    wxSizer:addSpacer(Szr2, 3),
+    wxSizer:add(Szr2, TileChk, [{proportion, 0}, {border, 2}, {flag, ?wxEXPAND}]),
     wxSizer:addSpacer(Szr2, 3),
     wxSizer:add(Szr2, OpaLbl, [{proportion, 0}, {border, 2}, {flag, ?wxEXPAND}]),
     wxSizer:add(Szr2, Opa, [{proportion, 0}, {border, 2}, {flag, ?wxEXPAND}]),
@@ -553,6 +588,7 @@ init([Frame, Name, {OpaVal}=State]) ->
     wxListBox:connect(ModLbx, left_up),
     wxListBox:connect(ModLbx, motion),
     wxListBox:connect(ModLbx, leave_window),
+    wxCheckBox:connect(TileChk, command_checkbox_clicked),
     wxSlider:connect(Opa,command_slider_updated),
     wxSlider:connect(Rot,command_slider_updated),
 
@@ -568,7 +604,7 @@ init([Frame, Name, {OpaVal}=State]) ->
     Entries = [],
     {Panel, #state{me=Panel, name=Name, shown=Entries, cols=Cols, state=State,
 		   ctrls=#{imglst=>ImgLst,actbtn=>BAct,ctrlbox=>CtrlBox,sldopa=>Opa,
-			   sldrot=>Rot,opalbl=>OpaLbl,rotlbl=>RotLbl}}}.
+			   sldrot=>Rot,opalbl=>OpaLbl,rotlbl=>RotLbl,tilechk=>TileChk}}}.
 
 setup_image_list(Ctrl) ->
     Images = find_images(),
@@ -653,6 +689,10 @@ handle_event(#wx{event=#wxCommand{type=command_togglebutton_clicked}, obj=Btn},
 handle_event(#wx{event=#wxCommand{type=command_button_clicked}}, State) ->
     wings_wm:psend(geom, {action,{snap_image,apply}}),
     {noreply, State};
+handle_event(#wx{event=#wxCommand{type=command_checkbox_clicked, commandInt=Val}, obj=_Obj}, State) ->
+    wings_wm:psend(geom, {action,{snap_image,{tiled,Val}}}),
+    {noreply, State};
+
 handle_event(#wx{event=#wxCommand{type=command_slider_updated, commandInt=Val}, obj=Obj},
 	     #state{ctrls=#{sldopa:=Opa,sldrot:=Rot,opalbl:=OpaLbl,rotlbl:=RotLbl}}=State) ->
     case Obj of
@@ -754,6 +794,7 @@ code_change(_From, _To, State) ->
     State.
 
 terminate(_Reason, #state{name=Name}) ->
+    erase(?MODULE),
     wings_wm:psend(geom, {action,{snap_image,cancel}}),
     wings ! {wm, {delete, Name}},
     normal.

--- a/plugins_src/commands/wpc_absolute_move.erl
+++ b/plugins_src/commands/wpc_absolute_move.erl
@@ -373,7 +373,7 @@ disable(all, Bool, Store) ->
     catch _:_ -> ignore end;
 disable(What, Bool, Store) ->
     try
-	wings_dialog:enable(depend(What), Bool, Store)
+	wings_dialog:enable(depend(What), not Bool, Store)
     catch _:_ -> ignore end.
 
 depend(lx) -> x;

--- a/plugins_src/commands/wpc_absolute_scale.erl
+++ b/plugins_src/commands/wpc_absolute_scale.erl
@@ -135,7 +135,7 @@ getSuggestedCenter([{AX1,AY1,AZ1},{AX2,AY2,AZ2}],
      getC(AY1,AY2,BY1,BY2),
      getC(AZ1,AZ2,BZ1,BZ2)}.
 
-getC(A1, A2, B1, B2) when A1 =/= A2, B1 =/= B2 ->
+getC(A1, A2, B1, B2) when A1 =/= A2, B1 =/= B2, ((A1 - A2)-(B1 - B2))=/=0.0 ->
     (B1*A2-B2*A1)/((A2-A1) - (B2-B1));
 getC(A1, A2, _, _) -> (A1+A2)/2.
 

--- a/plugins_src/commands/wpc_sweep_extrude.erl
+++ b/plugins_src/commands/wpc_sweep_extrude.erl
@@ -186,7 +186,7 @@ collect_data([Fs0|Rs], #we{mirror=M}=We, Axis0, SelC0, AllVs0, State,
                 true ->
                      LoopVs0
     end,
-    Axis = wings_util:make_vector(Axis0),
+    Axis = axis_conversion(Axis0),
 
     ExVs = ordsets:subtract(RegVs, LoopVs),
     AllVs = ordsets:union(RegVs ,AllVs0),
@@ -487,6 +487,20 @@ seed_face(_,Vpos,{{_,_,LoopNorm,_,_,Axis},{Norm,Center}},{Angle,_Dist,_Rotate,_S
     end.
 
 %%%%  Helper functions
+axis_conversion(Axis) ->
+    case Axis of
+        x -> wings_util:make_vector(Axis);
+        y -> wings_util:make_vector(Axis);
+        z ->  wings_util:make_vector(Axis);
+        free -> view_vector();
+        last_axis ->
+            {_, Dir} = wings_pref:get_value(last_axis),
+            Dir;
+        default_axis ->
+            {_, Dir} = wings_pref:get_value(default_axis),
+            Dir;
+        {_,_,_} ->  wings_util:make_vector(Axis)
+    end.
 
 intersect_vec_plane(PosA,PosB,PlaneNorm) ->
     %% Return point where Vector through PosA intersects with plane at PosB

--- a/plugins_src/import_export/wpc_lwo.erl
+++ b/plugins_src/import_export/wpc_lwo.erl
@@ -261,14 +261,18 @@ make_vmad_uv2(IndexedFaces, UVcoords) ->
 	#e3d_face{tx=FaceUVs,vs=FaceVerts} = E3dFace,
 	FaceIdxs = lists:duplicate(length(FaceVerts), FaceIdx),
 	RawFaceUvs = [lists:nth(Index+1, UVcoords) || Index <- FaceUVs],
-	FaceVertsB = [<<I:16>> || I <- FaceVerts],
-	FaceIdxsB  = [<<I:16>> || I <- FaceIdxs],
 	RawFaceUvsB = [<<U:32/float, V:32/float>> || {U,V} <- RawFaceUvs],
-	Line = zip_lists_3(FaceVertsB, FaceIdxsB, RawFaceUvsB),
-	list_to_binary(Line)
-	end,
+	case RawFaceUvs of
+	    [] -> [];
+	    _ ->
+		FaceVertsB = [<<I:16>> || I <- FaceVerts],
+		FaceIdxsB  = [<<I:16>> || I <- FaceIdxs],
+		Line = zip_lists_3(FaceVertsB, FaceIdxsB, RawFaceUvsB),
+		list_to_binary(Line)
+	end
+    end,
     Vmads = lists:map(FaceToBinary, IndexedFaces),
-    Vmads.
+    lists:flatten(Vmads).
 
 make_auth(Creator) ->
     Comment = make_nstring("----> Exported from: " ++ Creator ++ " <----"),

--- a/src/wings.erl
+++ b/src/wings.erl
@@ -1203,8 +1203,13 @@ drop_command(cancel_drop, St) -> St.
 %%%
 
 save_windows() ->
-    TopSize = wxWindow:getSize(?GET(top_frame)),
-    wings_pref:set_value(window_size, TopSize),
+    Frame = ?GET(top_frame),
+    case wxTopLevelWindow:isMaximized(Frame) of
+	false ->
+	    TopSize = wxWindow:getSize(?GET(top_frame)),
+	    wings_pref:set_value(window_size, TopSize);
+	true -> ignore
+    end,
     {Contained, Free} = wings_frame:export_layout(),
     wings_pref:set_value(saved_windows2, {Contained, Free}).
 

--- a/src/wings.erl
+++ b/src/wings.erl
@@ -1216,7 +1216,7 @@ save_windows() ->
     Frame = ?GET(top_frame),
     case wxTopLevelWindow:isMaximized(Frame) of
 	false ->
-	    TopSize = wxWindow:getSize(?GET(top_frame)),
+	    TopSize = wxWindow:getSize(Frame),
 	    wings_pref:set_value(window_size, TopSize);
 	true -> ignore
     end,

--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -629,11 +629,11 @@ autosave(#st{file=Name}=St) ->
 autosave_filename(File) ->
     Base = filename:basename(File),
     Dir = filename:dirname(File),
-    filename:join(Dir, "#" ++ Base ++ "#").
+    Dir ++ "/#" ++ Base ++ "#".
 
 unsaved_filename() ->
     Dir = wings_pref:get_dir(),
-    filename:join(Dir, ?UNSAVED_NAME).
+    Dir ++ "/" ++ ?UNSAVED_NAME.
 
 backup_filename(File) ->
     File ++ "~".

--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -303,6 +303,7 @@ confirmed_new(#st{file=File}=St) ->
 new(#st{saved=true}=St0) ->
     St1 = clean_st(St0#st{file=undefined}),
     %% clean_st/1 will remove all saved view, but will not reset the view. For a new project we should reset it.
+    wings_frame:reinit_layout(),
     wings_view:reset(),
     St2 = clean_images(wings_undo:init(St1)),
     St = wings_obj:create_folder_system(St2),
@@ -348,6 +349,7 @@ confirmed_open(Name, St0) ->
 		  %%   Name: Original name of file to be opened.
 		  %%   File: Either original file or the autosave file
 		  St1 = clean_st(St0#st{file=undefined}),
+		  wings_frame:reinit_layout(),
 		  St2 = wings_obj:create_folder_system(wings_undo:init(St1)),
 		  case ?SLOW(wings_ff_wings:import(File, St2)) of
 		      #st{}=St3 ->

--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -14,7 +14,7 @@
 -module(wings_file).
 -export([init/0,init_autosave/0,menu/0,command/2]).
 -export([import_filename/2,export_filename/2,export_filename/3]).
--export([unsaved_filename/0,autosave_filename/1]).
+-export([unsaved_filename/0,del_unsaved_file/0,autosave_filename/1]).
 -export([file_filters/1]).
 
 -include("wings.hrl").

--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -14,7 +14,7 @@
 -export([top_menus/0, make_win/2, register_win/3, close/1, set_focus/1,set_title/2,
          get_top_frame/0,
          show_toolbar/1,
-	 export_layout/0, import_layout/2,
+	 export_layout/0, import_layout/2, reinit_layout/0,
 	 get_overlay/0, overlay_draw/3, overlay_hide/1,
 	 get_icon_images/0, get_colors/0, update_theme/0]).
 
@@ -112,6 +112,18 @@ export_layout() ->
     Contained = filter_contained(Contained0, AddProps, []),
     Free = [AddProps(Win) || Win <- Free0, save_window(element(1,Win))],
     {Contained, Free}.
+
+reinit_layout() ->
+    {Contained, Free} = wx_object:call(?MODULE, get_windows),
+    Delete = fun(Name) ->
+	wings_wm:delete(Name),
+	case ?IS_GEOM(Name) of
+	    true  -> ignore;
+	    false -> receive {wm, {delete, Name}} -> ok end
+	end
+	     end,
+    [Delete(Win) || {Win, _, _, _} <- Contained ++ Free, not save_window(Win)],
+    ok.
 
 get_icon_images() ->
     wx_object:call(?MODULE, get_images).

--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -446,6 +446,12 @@ handle_call(get_overlay, _From, #state{overlay=Overlay}=State) ->
     {reply, Overlay, State};
 
 handle_call({update_layout,Contained0}, _From, #state{windows=#{ch:=Split}}=State) ->
+    {W, H} = TopSize = wings_pref:get_value(window_size),
+    Frame = ?GET(top_frame),
+    case wxWindow:getSize(Frame) of
+	TopSize -> ignore;
+	_ -> wxWindow:setSize(Frame, W, H)
+    end,
     Contained = [C || C = {Type, _, _} <- Contained0, Type=:=split orelse Type=:=split_rev],
     update_layout(Contained, Split),
     {reply, ok, State};

--- a/src/wings_pref_dlg.erl
+++ b/src/wings_pref_dlg.erl
@@ -579,6 +579,7 @@ smart_set_value_1(Key, Val, St) ->
 			    "effect the next time Wings 3D is started."),
 		    wings_u:message(Str);
                 show_toolbar ->
+                    delayed_set_value(Key, OldVal, Val),
                     wings_frame:show_toolbar(Val);
 		extended_toolbar ->
 		    delayed_set_value(Key, OldVal, Val),

--- a/src/wings_toolbar.erl
+++ b/src/wings_toolbar.erl
@@ -90,6 +90,7 @@ init(Frame, Icons) ->
     %% wxToolBar:connect(TB, comand_tool_rclicked, [{skip, true}]),
     %% wxToolBar:connect(TB, comand_tool_enter, [{skip, true}]),
     wxToolBar:realize(TB),
+    wxToolBar:show(TB, [{show, wings_pref:get_value(show_toolbar)}]),
     State = #{me=>TB, mode=>vertex, sh=>true, restr=>none, bs=>Bs, active=>geom, wins=>#{}},
     update({selmode, geom, face, true}, State).
 

--- a/src/wings_we.erl
+++ b/src/wings_we.erl
@@ -700,7 +700,13 @@ do_renumber(#we{vp=Vtab0,es=Etab0,fs=Ftab0,
 	       _ -> Perm0
 	   end,
 
-    Holes = [gb_trees:get(F, Fmap) || F <- Holes0],
+    Holes =
+    	lists:foldr(fun(F, Acc) ->
+			case gb_trees:lookup(F, Fmap) of
+			    {value,_} -> [F|Acc];
+			    none -> Acc
+			end
+		    end, [], Holes0),
 
     Mirror = if
 		 Mirror0 =:= none -> Mirror0;

--- a/src/wings_we.erl
+++ b/src/wings_we.erl
@@ -700,13 +700,7 @@ do_renumber(#we{vp=Vtab0,es=Etab0,fs=Ftab0,
 	       _ -> Perm0
 	   end,
 
-    Holes =
-    	lists:foldr(fun(F, Acc) ->
-			case gb_trees:lookup(F, Fmap) of
-			    {value,_} -> [F|Acc];
-			    none -> Acc
-			end
-		    end, [], Holes0),
+    Holes = [gb_trees:get(F, Fmap) || F <- Holes0],
 
     Mirror = if
 		 Mirror0 =:= none -> Mirror0;

--- a/src/wings_we.erl
+++ b/src/wings_we.erl
@@ -831,7 +831,12 @@ separate_1(#we{es=Etab0}=We, Smallest0, Acc) ->
 	    {Edge,Smallest} = smallest(Smallest0, Etab0),
 	    Ws = gb_sets:singleton(Edge),
 	    {EtabLeft,NewEtab} = separate(Ws, Etab0, array:new()),
-	    NewWe = copy_dependents(We#we{es=NewEtab}),
+	    NewWe0 = copy_dependents(We#we{es=NewEtab}),
+	    NewWe =
+		case wings_we:all_hidden(NewWe0) of
+		    true -> show_faces(NewWe0#we{perm=?PERM_HIDDEN_BIT});  %Hide entire object.
+		    false -> NewWe0
+		end,
 	    separate_1(We#we{es=EtabLeft}, Smallest, [NewWe|Acc])
     end.
 


### PR DESCRIPTION
- Fixed the hidden object after Separate has been used;
- Fixed crash caused by collapsing edges from a hidden face;
- Prevent Wings3D to save the window's size if it is maximized;
- Added a dialog to allow user to decide if a unsaved file must be recovered;
- Fixed bad objects count for each folder in the Geometry Graph window;
- Fixed the action for "show bar" option in preferences dialog;
- Fixed the main window size management in preferences subset routine;
- Removed unwanted window after load or start a new project;
- Fixed a silent error injected by the current björn's changes;
- Fixed a crash in Lightwave exporter when there is wrong UV info;
- Fixed autosave/save actions when storing files using a network address;
- Enabled Wavefront importer to read unicode files;
- Fixed dialog for Absolute Move in which the Lock controls was working inverted;

_OBS: Just for your information: it could be added new commits further, but if you decide to build a new version you can merge and close this PR._