### PR TITLE
Added the OS and GPU information to the crash dump file.

### DIFF
--- a/src/wings_u.erl
+++ b/src/wings_u.erl
@@ -99,6 +99,13 @@ crash_log(WinName, Reason, StackTrace) ->
     F = open_log_file(LogName),
     io:format("Internal Error~n",[]),
     [io:format(Fd, "Version: ~s\n", [?WINGS_VERSION]) || Fd <- [F, group_leader()]],
+    try
+	[io:format(Fd, "OS: ~ts\n", [wx_misc:getOsDescription()])  || Fd <- [F, group_leader()]],
+	[io:format(Fd, "GPU: ~ts | ~ts\n",
+		   [gl:getString(?GL_VENDOR), gl:getString(?GL_RENDERER)])  || Fd <- [F, group_leader()]]
+    catch
+	_ -> ignore
+    end,
     [io:format(Fd, "Window: ~p\n", [WinName])  || Fd <- [F, group_leader()]],
     [io:format(Fd, "Reason: ~p\n\n", [Reason]) || Fd <- [F, group_leader()]],
     report_stacktrace(F, StackTrace),


### PR DESCRIPTION
The intention is to get some extra information from the user since most the time they don't provide us (without ask for) and it can be relevant in some circumstances.

It will look like this

> Dump written 2017-2-16_11-41
> Version: 2.1.5.154.g423ed
> **OS: Windows 7 (build 7601, Service Pack 1), 64-bit edition
> GPU: Intel | Intel(R) HD Graphics**
> Window: geom
> Reason: function_clause
> ...
