### PR TITLE
Added F2 and Del hotkeys to Outliner window

### DIFF
--- a/plugins_src/commands/wpc_sel_win.erl
+++ b/plugins_src/commands/wpc_sel_win.erl
@@ -16,11 +16,13 @@
 -export([window/1,window/5]).
 
 -export([init/1,
-	 handle_call/3, handle_cast/2, handle_event/2, handle_info/2,
-	 code_change/3, terminate/2
+	 handle_call/3, handle_cast/2,
+	 handle_event/2, handle_sync_event/3,
+	 handle_info/2, code_change/3, terminate/2
 	]).
 
 -define(WIN_NAME, {plugin, sel_groups}).
+-define(NEED_ESDL, true).
 -include_lib("wings/src/wings.hrl").
 
 %%%
@@ -204,7 +206,25 @@ init([Frame, _Ps, SS]) ->
     wxWindow:connect(LC, command_list_end_label_edit),
     wxWindow:connect(LC, size, [{skip, true}]),
     wxWindow:connect(LC, enter_window, [{userData,{win,Panel}}]),
+    wxWindow:connect(LC, char, [callback]),
     {Panel, #state{lc=LC, shown=Shown, ss=SS, sel=none}}.
+
+handle_sync_event(#wx{obj=LC,event=#wxKey{type=char, keyCode=KC}}, EvObj, #state{lc=LC, shown=Shown}) ->
+    Indx = wxListCtrl:getNextItem(LC, -1, [{geometry, ?wxLIST_NEXT_ALL}, {state, ?wxLIST_STATE_SELECTED}]),
+    case {key_to_op(KC), validate_param(Indx)} of
+	{Act,Param0} when Act =/= ignore andalso Param0 =/=ignore ->
+	    Param = array:get(Param0, Shown),
+	    wings_wm:psend(?WIN_NAME, {action, {sel_groups, {Act, Param}}});
+	_ -> wxEvent:skip(EvObj, [{skip, true}])
+    end,
+    ok.
+
+key_to_op(?WXK_DELETE) -> delete_group;
+key_to_op(?WXK_F2) -> rename_group;
+key_to_op(_) -> ignore.
+
+validate_param(-1) -> ignore;
+validate_param(Param) -> Param.
 
 handle_event(#wx{event=#wxList{type=command_list_item_activated, itemIndex=Indx}},
  	     #state{shown=Shown} = State) ->
@@ -408,8 +428,10 @@ group_ins_menu() ->
 	[{?__(1,"New Group..."),menu_cmd(new_group,0),?__(2,"Create a new selection group")}].
 group_del_menu(none) -> [];
 group_del_menu({_,SrcName}=SrcId) ->
-	[{?__(20,"Rename"), menu_cmd(rename_group,SrcId), ?__(21,"Rename group \"")++SrcName++"\""},
-	 {?__(3,"Delete Group"), menu_cmd(delete_group,SrcId), ?__(4,"Delete group \"")++SrcName++"\""},
+	[{?__(20,"Rename"), menu_cmd(rename_group,SrcId),
+	  ?__(21,"Rename group \"")++SrcName++"\"", [{hotkey,wings_hotkey:format_hotkey({?SDLK_F2,[]},pretty)}]},
+	 {?__(3,"Delete Group"), menu_cmd(delete_group,SrcId),
+	  ?__(4,"Delete group \"")++SrcName++"\"", [{hotkey,wings_hotkey:format_hotkey({?SDLK_DELETE,[]},pretty)}]},
 	 separator,
 	 {?__(22,"Delete All"), menu_cmd(delete_groups,all), ?__(23,"Delete all groups")},
 	 {?__(24,"Remove Invalid Groups"), menu_cmd(delete_groups,invalid), ?__(25,"Removes all invalid groups")}].

--- a/src/wings_outliner.erl
+++ b/src/wings_outliner.erl
@@ -722,16 +722,16 @@ do_menu(#{type:=mat, name:=Name}) ->
      {?__(7,"Duplicate"),menu_cmd(duplicate_material, Name),
       ?__(8,"Duplicate this material")},
      {?__(9,"Delete"),menu_cmd(delete_material, Name),
-      ?__(10,"Delete this material")},
+      ?__(10,"Delete this material"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_DELETE,[]},pretty)}]},
      {?__(11,"Rename"),menu_cmd(rename_material, Name),
-      ?__(12,"Rename this material")}];
+      ?__(12,"Rename this material"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_F2,[]},pretty)}]}, []];
 do_menu(#{type:=object, id:=Id}) ->
     [{?__(13,"Duplicate"),menu_cmd(duplicate_object, Id),
       ?__(14,"Duplicate this object")},
      {?__(15,"Delete"),menu_cmd(delete_object, Id),
-      ?__(16,"Delete this object")},
+      ?__(16,"Delete this object"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_DELETE,[]},pretty)}]},
      {?__(17,"Rename"),menu_cmd(rename_object, Id),
-      ?__(18,"Rename this object")}];
+      ?__(18,"Rename this object"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_F2,[]},pretty)}]}];
 do_menu(#{type:=light, id:=Id}) ->
     [{?__(19,"Edit Light..."),menu_cmd(edit_light, Id),
       ?__(20,"Edit light properties")},
@@ -739,9 +739,9 @@ do_menu(#{type:=light, id:=Id}) ->
      {?__(21,"Duplicate"),menu_cmd(duplicate_object, Id),
       ?__(22,"Duplicate this light")},
      {?__(23,"Delete"),menu_cmd(delete_object, Id),
-      ?__(24,"Delete this light")},
+      ?__(24,"Delete this light"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_DELETE,[]},pretty)}]},
      {?__(25,"Rename"),menu_cmd(rename_object, Id),
-      ?__(26,"Rename this light")}];
+      ?__(26,"Rename this light"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_F2,[]},pretty)}]}];
 do_menu(#{type:=image, id:=Id, image:=Im}=Map) ->
     image_menu(Id, Im, maps:get(mat, Map, unused)).
 
@@ -759,7 +759,8 @@ image_menu_1(Id, _, Mat) ->
 
 image_menu_2(Id, unused) ->
     [separator,
-     {?__(1,"Delete"),menu_cmd(delete_image, Id), ?__(2,"Delete selected image")}
+     {?__(1,"Delete"),menu_cmd(delete_image, Id),
+      ?__(2,"Delete selected image"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_DELETE,[]},pretty)}]}
      |command_image_menu(Id)];
 image_menu_2(Id, {Mat, Type}) ->
     [separator,
@@ -778,7 +779,7 @@ command_image_menu(Id) ->
      {?__(3,"Duplicate"),menu_cmd(duplicate_image, Id),
       ?__(4,"Duplicate selected image")},
      {?__(7,"Rename"),menu_cmd(rename_image, Id),
-      ?__(8,"Rename selected image")}
+      ?__(8,"Rename selected image"),[{hotkey,wings_hotkey:format_hotkey({?SDLK_F2,[]},pretty)}]}
     ].
 
 handle_drop(#{type:=image, id:=Id}, #{type:=mat, name:=Name}) ->

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -1048,6 +1048,8 @@ views({jump,J}, #st{views={CurrentView,Views}}=St) ->
     views_jump(J, St, CurrentView, Views);
 views({move,J}, #st{views={CurrentView,Views}}=St) ->
     views_move(J, St, CurrentView, Views);
+views({rename,Idx}, #st{views={_,Views}}=St) ->
+    views(rename, St#st{views={Idx,Views}});
 views(rename, #st{views={CurrentView,Views}}=St) ->
     J = view_index(CurrentView, tuple_size(Views)),
     {View,Legend} = element(J, Views),


### PR DESCRIPTION
The dockable windows Outliner, Saved Views, Selection Groups and Geometry Graph had enabled the use of the hotkeys "F2" and "Delete" for rename and delete operations respectively.