### PR TITLE
Added a system notifier for when a new project is just started

### DIFF
--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -182,6 +182,8 @@ save_unused_mats() ->
 
 command(new, St) ->
     new(St);
+command(new_ready, St) ->
+    St;
 command(confirmed_new, St) ->
     del_unsaved_file(),
     confirmed_new(St);
@@ -308,6 +310,7 @@ new(#st{saved=true}=St0) ->
     St2 = clean_images(wings_undo:init(St1)),
     St = wings_obj:create_folder_system(St2),
     wings_u:caption(St),
+    wings_wm:psend(wings_wm:this(),{action,{file,new_ready}}),
     {new,St#st{saved=true}};
 new(#st{}=St0) ->		      %File is not saved or autosaved.
     wings_u:caption(St0#st{saved=false}),


### PR DESCRIPTION
Wings3D make a pst available for #st{} structure that can be used by
plugins for keeping its own data, but it doesn't allow a way to notify
the plygins about a new project be starting and allowing them to make
any kind of needed cleanup. That is what this notifier event do.

When user starts a new project without savind an project in use Wings3D
will fire a 'new' event signing a new projct was choosen, but the process
can be confirmed or canceled and depending on the user choice a new notifier
will be fired 'new_confirmed' and 'new_canceled'.

Plugins can use 'new_confirmed' in that case, but if the project was already
saved the only event fired is 'new' that is an uncertain situation.

The new 'new_ready' event ensures plugins can do any cleanup in #st{}.pst
without compromise any current state.

Bellow is a sample of events that plugin can manage for 'file' options related
to 'new':

We are in a 'New' project and we choose 'New' again
command file  new...
command file  new_ready...

After we create a new sece and choose 'New':

1) Hitting 'Cancel' in confirmation dialog (* cause uncertain state)
command file  new...

2) Hitting 'No' in confirmation dialog
command file  new...
command file  confirmed_new...
command file  new_ready...

3) Hitting 'Yes' in confirmation dialog
command file  new...
command file  new...
command file  new_ready...