### PR TITLE
[Option 1] Fixed the missing call to post hook in auto rotate mode

### DIFF
--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -655,9 +655,16 @@ redraw(St) ->
     Render =
 	fun() ->
 		wings_wm:clear_background(),
-		wings_render:render(St)
+		wings_render:render(St),
+	    	call_post_hook(St)
 	end,
     wings_io:batch(Render).
+
+call_post_hook(St) ->
+    case wings_wm:lookup_prop(postdraw_hook) of
+	none -> ok;
+	{value,{_Id,Fun}} -> Fun(St)
+    end.
 
 %%%
 %%% Magnet Radius Adjustments

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -710,6 +710,7 @@ auto_rotate_redraw(#tim{st=Redraw}) when is_function(Redraw) ->
 auto_rotate_redraw(#tim{st=#st{}=St}=Tim) ->
     wings_wm:clear_background(),
     wings_render:render(St),
+    call_post_hook(St),
     wings_io:info(timer_stats(Tim)).
 
 auto_rotate_help() ->
@@ -746,6 +747,12 @@ timer_stats(#tim{start=T0, frames=Fs}) ->
 
 get_event(Tim) ->
     {replace,fun(Ev) -> auto_rotate_event(Ev, Tim) end}.
+
+call_post_hook(St) ->
+    case wings_wm:lookup_prop(postdraw_hook) of
+	none -> ok;
+	{value,{_Id,Fun}} -> Fun(St)
+    end.
 
 %%%
 %%% Other stuff.


### PR DESCRIPTION
It was noticed the redraw function in auto rotate code (in wings_view module)
was not calling an user defined draw hook (via register_postdraw_hook).
When searching for render/1 calls I found that wings_tweak module has missed
it too.
As a simple fix, the function call_post_hook/1 in wings.erl was just replicated
to those modules (which I think it's not the right action).