### PR TITLE
[Option 2] Fixed the missing call to post hook in auto rotate mode

### DIFF
--- a/src/wings.erl
+++ b/src/wings.erl
@@ -264,7 +264,6 @@ redraw(Info, St) ->
 	fun() ->
 		wings_wm:clear_background(),
 		wings_render:render(St),
-		call_post_hook(St),
 		TweakInfo = wings_tweak:statusbar(),
 		case Info =/= [] andalso wings_wm:get_prop(show_info_text) of
 		    true when TweakInfo =:= [] ->
@@ -279,12 +278,6 @@ redraw(Info, St) ->
 		wings_tweak:tweak_keys_info()
 	end,
     wings_io:batch(Render).
-
-call_post_hook(St) ->
-    case wings_wm:lookup_prop(postdraw_hook) of
-    none -> ok;
-    {value,{_Id,Fun}} -> Fun(St)
-    end.
 
 register_postdraw_hook(Window, Id, Fun) ->
     case wings_wm:lookup_prop(Window, postdraw_hook) of

--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -53,8 +53,8 @@ render(#st{selmode=Mode}=St) ->
     axis_letters(PM,MM,Yon),
     show_camera_image_plane(),
     gl:popAttrib(),
-    wings_develop:gl_error_check("Rendering scene"),
-    call_post_hook(St).
+    call_post_hook(St),
+    wings_develop:gl_error_check("Rendering scene").
 
 call_post_hook(St) ->
     case wings_wm:lookup_prop(postdraw_hook) of

--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -53,7 +53,14 @@ render(#st{selmode=Mode}=St) ->
     axis_letters(PM,MM,Yon),
     show_camera_image_plane(),
     gl:popAttrib(),
-    wings_develop:gl_error_check("Rendering scene").
+    wings_develop:gl_error_check("Rendering scene"),
+    call_post_hook(St).
+
+call_post_hook(St) ->
+    case wings_wm:lookup_prop(postdraw_hook) of
+        none -> ok;
+        {value,{_Id,Fun}} -> Fun(St)
+    end.
 
 polygonOffset(M) ->
     case get(polygon_offset) of


### PR DESCRIPTION
It was noticed the redraw function in auto rotate code was not calling
an user defined draw hook (via register_postdraw_hook)

As the wings_render:render/1 is called from wings.erl, wings_tweak.erl and
wings_view.erl I believe the best option would be move that call to the
render module since it is always called just after render/1 be called.