### PR TITLE
Fix excessive duplication of objects in Absolute Move

### DIFF
--- a/plugins_src/commands/wpc_absolute_move.erl
+++ b/plugins_src/commands/wpc_absolute_move.erl
@@ -445,12 +445,7 @@ do_move_1(Origin, DuOrg, DupRT, Move, #st{selmode=Mode}=St) ->
          end,
     wings_sel:clone(CF, St).
 
-do_move_2(Vs, We, Origin, DuOrg, DupRT, Params) when DuOrg > 0 ->
-    [We|do_move_3(Vs, We, Origin, DuOrg, DupRT, Params)];
-do_move_2(Vs, We, Origin, DuOrg, DupRT, Params) ->
-    do_move_3(Vs, We, Origin, DuOrg, DupRT, Params).
-
-do_move_3(Vs, We0, Origin, DuOrg, DupRT,
+do_move_2(Vs, We0, Origin, DuOrg, DupRT,
           [CommonCenter,Pos,Wo,Align,Flatten,Du]) ->
     Center = wings_vertex:center(Vs, We0),
     D0 = d(Pos, Align, CommonCenter, Center),


### PR DESCRIPTION
If duplicates were chosen, there would be twice as many duplicates
created than requested. The bug was introduced in eef76b3a18032c64.