### PR TITLE
Fixed missed opengl window management for customised windows in plugins.

### DIFF
--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -1135,9 +1135,10 @@ geom_below(Pos) ->
 	true -> none;
 	false ->
             All = windows(),
+	    Geoms1 = [Geom|| {plugin,{_ModName,geom}}=Geom <- All],
             Geoms0 = [geom|[Geom|| {Win,_}=Geom <- All,
                                    Win =:= geom orelse Win =:= autouv]],
-            Geoms = [get_window_data(Name) || Name <- Geoms0],
+            Geoms = [get_window_data(Name) || Name <- Geoms0++Geoms1],
             find_window(Geoms, Geoms, Win0)
     end.
 


### PR DESCRIPTION
Theached the window management module (wings_wm) to understand that a custom
OpenGL window (usually named 'geom') created by a plugin needs to respond
to mouse over events just like a regular geom/{geom,<num>}/autouv window.

That ensures the user doesn't need to click on the window's work space to get
it focused as well as it can respond to hotkeys too - since it's now focused.

Anything esle is changed - it's not necessary to change the ?IS_GEOM macro or
is_geom/1 function.