### PR TITLE
Fixed an issue which was rollbacking the #st{} in sculpt mode

### DIFF
--- a/plugins_src/commands/wpc_sculpt.erl
+++ b/plugins_src/commands/wpc_sculpt.erl
@@ -4,19 +4,23 @@
 %%     A plugin to add a few basic sculpting tools.
 %%
 %%  Copyright (c) 2010-2012 Richard Jones
+%%                2018 Micheus (porting to use its own geometry window)
 %%
 %%  See the file "license.terms" for information on usage and redistribution
 %%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
 %%
 
 -module(wpc_sculpt).
--export([init/0,menu/2,command/2]).
+-export([init/0,menu/2,command/2,
+         win_data/1,window/5]).
 -export([update_dlist/3,draw/4,get_data/3]).
 
 -export([sculpt_menu/3]).
 
 -define(NEED_OPENGL, 1).
 -define(NEED_ESDL, 1).
+-define(WIN_GEOM_SCULPT, {plugin,{sculpt,geom}}).
+
 -include_lib("wings/src/wings.hrl").
 
 -import(lists, [foldl/3,sort/1,reverse/1,member/2]).
@@ -32,8 +36,7 @@
      mir,              % mirror info
      locked,           % masked vertices
      st,               % state
-     wst,              % working state
-     ost}).            % original state
+     wst}).            % original state
 
 init() ->
     wings_pref:set_default(sculpt_strength, 0.005),
@@ -66,11 +69,24 @@ sculpt_heading() ->
 command({tools,sculpt}, St) ->
     sculpt_mode_setup(St);
 command({sculpt,_}, St) -> St;
+command({file,{confirmed_open,_}}, St) ->
+    %% it happens for File->Open and File->Recent if the user SAVED or NOT its work
+    wings_wm:send(?WIN_GEOM_SCULPT, {reset_sculpt_state,St}),
+    next;
 command(_,_) -> next.
 
-sculpt_mode_setup(#st{shapes=Shs}=St0) ->
-    wings_tweak:toggle_draw(false),
-    St = wings_undo:init(St0#st{selmode=face,sel=[],sh=false}),
+win_data(?WIN_GEOM_SCULPT) ->
+    {?WIN_GEOM_SCULPT, {right,[]}}.
+
+window(Name, Pos, Size, Ps0, St) ->
+    Sc = init_sculpt_state(St),
+    new_viewer(Name, Pos, Size, Ps0, Sc).
+
+title(?WIN_GEOM_SCULPT) ->
+    ?STR(title,1,"Geometry (Sculpt mode)").
+
+init_sculpt_state(#st{shapes=Shs}=St0) ->
+    St = wings_undo:init(St0#st{selmode=face,sh=false}),
     Mir = mirror_info(Shs, []),
     Mode = wings_pref:get_value(sculpt_mode),
     Str = wings_pref:get_value(sculpt_strength),
@@ -78,11 +94,37 @@ sculpt_mode_setup(#st{shapes=Shs}=St0) ->
     MagType = wings_pref:get_value(sculpt_magnet_type),
     Lv = shape_attr(gb_trees:to_list(Shs)),
     wings_pref:set_default(sculpt_current_id, none),
-    Sc = #sculpt{mode=Mode,mir=Mir,str=Str,mag=Mag,rad=Rad,mag_type=MagType,
-          locked=Lv,st=St,wst=St,ost=St0},
-    wings:mode_restriction([face]),
-    wings_wm:dirty(),
-    {seq,push,update_sculpt_handler(Sc)}.
+    #sculpt{mode=Mode,mir=Mir,str=Str,mag=Mag,rad=Rad,mag_type=MagType,
+            locked=Lv,st=St,wst=St}.
+
+sculpt_mode_setup(St) ->
+    Sc = init_sculpt_state(St),
+    case wings_wm:is_window(?WIN_GEOM_SCULPT) of
+        false ->
+            new_viewer(Sc);
+        _ ->
+            wings_wm:raise(?WIN_GEOM_SCULPT)
+    end,
+    keep.
+
+new_viewer(Sc) ->
+    Size = wings_wm:win_size(geom),
+    Props = [{display_data,geom_display_lists}|wings_wm:get_props(geom)],
+    new_viewer(?WIN_GEOM_SCULPT, {50,50}, Size, Props, Sc).
+
+new_viewer(Name, Pos, Size, Props, Sc) ->
+    Op = {seq,push,update_sculpt_handler(Sc)},
+    Title = title(Name),
+    {Frame,Ps} = wings_frame:make_win(Title, [{size, Size}, {pos, Pos}|Props]),
+    Context = wxGLCanvas:getContext(?GET(gl_canvas)),
+    Show = proplists:is_defined(external, Ps),
+    Canvas = wings_gl:window(Frame, Context, true, Show),
+    wings_wm:toplevel(Name, Canvas, Ps ++ initial_properties(), Op),
+    Name.
+
+initial_properties() ->
+    [{display_data,geom_display_lists},{mode_restriction,[face]}] ++
+    wings_view:initial_properties().
 
 shape_attr(S) ->
     L = foldl(fun
@@ -114,30 +156,43 @@ handle_sculpt_event_0(redraw, #sculpt{st=St}=Sc) ->
     wings:redraw("",St),
     help(Sc),
     update_sculpt_handler(Sc);
+handle_sculpt_event_0(close, Sc) ->
+    exit_sculpt(Sc);
 handle_sculpt_event_0(Ev, #sculpt{active=true}=Sc) ->
     handle_sculpt_event_1(Ev, Sc);
+handle_sculpt_event_0({reset_sculpt_state,#st{shapes=Shs}=St0}, Sc) ->
+    St = wings_undo:init(St0#st{selmode=face,sh=false}),
+    Mir = mirror_info(Shs, []),
+    Lv = shape_attr(gb_trees:to_list(Shs)),
+    update_sculpt_handler(Sc#sculpt{mir=Mir,locked=Lv,st=St,wst=St});
 handle_sculpt_event_0({update_state,St}, Sc) ->
-    wings_draw:refresh_dlists(St),
+    wings_draw:refresh_dlists(St#st{sel=[]}),
     wings_wm:current_state(St),
     update_sculpt_handler(Sc#sculpt{st=St,wst=St});
 handle_sculpt_event_0({current_state,St}, #sculpt{st=St}) ->
     keep;
-handle_sculpt_event_0({current_state,#st{shapes=Shs}=St1},
+handle_sculpt_event_0({current_state,#st{saved=Saved,file=File,shapes=Shs}=St1},
   #sculpt{st=St0}=Sc) ->
+    St =
+        case {Saved,File==undefined} of
+            {true,true} ->  %% That means a new project was just started
+                St1;
+            _ ->
+                wings_undo:save(St0, St1)
+        end,
     Mir = mirror_info(Shs, []),
     Lv = shape_attr(gb_trees:to_list(Shs)),
-    St = wings_undo:save(St0, St1),
     update_sculpt_handler(Sc#sculpt{locked=Lv,mir=Mir,st=St,wst=St});
 handle_sculpt_event_0({new_state,#st{shapes=Shs}=St1},
   #sculpt{st=St0}=Sc) ->
     Mir = mirror_info(Shs, []),
     Lv = shape_attr(gb_trees:to_list(Shs)),
-    St = wings_undo:save(St0, St1#st{sel=[],selmode=face,sh=false}),
-    wings_draw:refresh_dlists(St),
+    St = wings_undo:save(St0, St1#st{selmode=face,sh=false}),
+    wings_draw:refresh_dlists(St#st{sel=[]}),
     wings_wm:current_state(St),
     update_sculpt_handler(Sc#sculpt{locked=Lv,mir=Mir,st=St,wst=St});
 handle_sculpt_event_0(Ev, #sculpt{st=St}=Sc) ->
-    case wings_camera:event(Ev, St) of
+    case wings_camera:event(Ev, St#st{sel=[]}) of
       next -> handle_sculpt_event_1(Ev, Sc);
       Other -> Other
     end.
@@ -155,7 +210,7 @@ handle_sculpt_event_1(#mousebutton{state=?SDL_RELEASED},
 		      #sculpt{active=true}=Sc) ->
     #sculpt{st=#st{shapes=Shs},wst=St0} =Sc0=clear_influence(Sc),
     St = wings_undo:save(St0, St0#st{shapes=Shs}),
-    wings_draw:refresh_dlists(St),
+    wings_draw:refresh_dlists(St#st{sel=[]}),
     wings_wm:current_state(St),
     wings_wm:dirty(), % it was necessary when I tested in a Intel video card
     update_sculpt_handler(Sc0#sculpt{id=none,st=St,wst=St,active=false});
@@ -181,9 +236,12 @@ handle_sculpt_event_1(#keyboard{sym=Sym,mod=Mod,state=?SDL_PRESSED}=Ev, #sculpt{
 handle_sculpt_event_1({action,Action}, Sc) ->
     command_handling(Action, Sc);
 handle_sculpt_event_1(got_focus, #sculpt{st=St}=Sc) ->
+    wings_tweak:toggle_draw(false),
     Str = wings_pref:get_value(sculpt_strength),
+    wings_draw:refresh_dlists(St#st{sel=[]}),
     wings_wm:dirty(),
-    update_sculpt_handler(Sc#sculpt{id=none,st=St#st{selmode=face,sel=[],sh=false},active=false,str=Str});
+    update_sculpt_handler(Sc#sculpt{id=none,st=St#st{selmode=face,sh=false},
+                                    active=false,str=Str});
 handle_sculpt_event_1(lost_focus, #sculpt{st=#st{shapes=Shs},wst=St0,active=true}=Sc) ->
     St = wings_undo:save(St0, St0#st{shapes=Shs}),
     wings_wm:current_state(St),
@@ -210,7 +268,7 @@ update_magnet_handler(X, Y, Sc) ->
         handle_magnet_event(Ev, X, Y, Sc) end}.
 
 handle_magnet_event(redraw, X, Y, #sculpt{st=St}=Sc) ->
-    wings_draw:refresh_dlists(St),
+    wings_draw:refresh_dlists(St#st{sel=[]}),
     wings:redraw("", St),
     help(Sc),
     draw_magnet(X, Y, Sc),
@@ -331,7 +389,7 @@ do_sculpt(X, Y, Sc) ->
     case sculpt(X, Y, Sc) of
       keep -> keep;
       {St,Id0} ->
-        wings_draw:refresh_dlists(St),
+        wings_draw:refresh_dlists(St#st{sel=[]}),
         wings_wm:dirty(),
         Id = case wings_pref:get_value(sculpt_initial) of
             true -> Id0;
@@ -732,24 +790,24 @@ command_handling(Action, #sculpt{st=St0,mag=Mag}=Sc) ->
               keep ->
 		  keep;
               #st{}=St ->
-                  wings_draw:refresh_dlists(St),
+                  wings_draw:refresh_dlists(St#st{sel=[]}),
 		  wings_wm:dirty(),
                   update_sculpt_handler(Sc#sculpt{st=St})
           end;
       {edit,undo_toggle} ->
           St = wings_u:caption(wings_undo:undo_toggle(St0)),
           wings_wm:current_state(St),
-          wings_draw:refresh_dlists(St),
+          wings_draw:refresh_dlists(St#st{sel=[]}),
           update_sculpt_handler(Sc#sculpt{st=St});
       {edit,undo} ->
           St = wings_u:caption(wings_undo:undo(St0)),
           wings_wm:current_state(St),
-          wings_draw:refresh_dlists(St),
+          wings_draw:refresh_dlists(St#st{sel=[]}),
           update_sculpt_handler(Sc#sculpt{st=St});
       {edit,redo} ->
           St = wings_u:caption(wings_undo:redo(St0)),
           wings_wm:current_state(St),
-          wings_draw:refresh_dlists(St),
+          wings_draw:refresh_dlists(St#st{sel=[]}),
           update_sculpt_handler(Sc#sculpt{st=St});
       {sculpt,Mode} when Mode =:= pull; Mode =:= pinch; Mode =:= smooth ->
           wings_wm:dirty(),
@@ -791,9 +849,9 @@ command_handling(Action, #sculpt{st=St0,mag=Mag}=Sc) ->
 	{hotkey, Cmd} ->
 	    wings_hotkey:command({Cmd,Sc}, St0);
 	{window, _} ->
-	    defer;
+            wings_wm:send(geom,{action,Action});
 	{file, _} ->
-	    defer;
+            wings_wm:send(geom,{action,Action});
       _ -> keep
     end.
 
@@ -801,7 +859,7 @@ command_handling(Action, #sculpt{st=St0,mag=Mag}=Sc) ->
 %%% Exit Sculpt
 %%%
 
-exit_sculpt(#sculpt{mag=Mag,mag_type=MagType,str=Str,rad=Rad,mode=Mode,ost=St0}=Sc) ->
+exit_sculpt(#sculpt{mag=Mag,mag_type=MagType,str=Str,rad=Rad,mode=Mode,st=St0}=Sc) ->
     wings_pref:set_value(sculpt_mode, Mode),
     wings_pref:set_value(sculpt_magnet, {Mag,Rad}),
     wings_pref:set_value(sculpt_strength, Str),
@@ -811,7 +869,7 @@ exit_sculpt(#sculpt{mag=Mag,mag_type=MagType,str=Str,rad=Rad,mode=Mode,ost=St0}=
     St = wings_undo:save(St0, St0#st{shapes=Shs}),
     wings:clear_mode_restriction(),
     wings_wm:later({new_state,St}),
-    pop.
+    delete.
 
 %%%
 %%% Info Line


### PR DESCRIPTION
The problem stated after the UI migration. Before the main menu was disabled
in Sculpt mode and that couldn't happens.
It now can deal with that as well as the synchronization between geometry
windows is better. Originally, the sculpt states was storing a #st{} structure
three times. After the changes, it can now keep only two of them.
I avoided to make a drastic change in the code, so maybe in the future we could
evaluate a way to store only one #st{} structre ('stw' - the internal work one)
as well as remove any event that became obsolete now.
I tested the save/restore windows; the File menu options with the plugin active
and no problem was verified.

NOTE: Fixed the problem that was causing geometry state rollback after
save a project in Sculpt mode. Thanks to tkbd.