### PR TITLE
Fixed crash in Select By Short Edge command

### DIFF
--- a/src/wings_sel_cmd.erl
+++ b/src/wings_sel_cmd.erl
@@ -826,7 +826,7 @@ short_edges(Ask, St) when is_atom(Ask) ->
     Title = ?__(2,"Select Short Edges"),
     Cmd = {select,by,short_edges},
     wings_dialog:dialog_preview(Cmd, Ask, Title, Qs, St);
-short_edges([Tolerance], #st{sel=[]}=St0) ->
+short_edges([Tolerance], St0) ->
     St = intersect_sel_items(fun(Edge, We) ->
 				     is_short_edge(Tolerance, Edge, We)
 			     end, edge, St0),


### PR DESCRIPTION
The select by short edge was causing Wings3D to crash dua a wrong function
bind. There is no need to restrict the command to unselected objects.
In fact, the code was already ready to deal with partial selections and
look for short edges only in selections.

NOTE: Fixed the cause of Select By Short Edge be crashing when there was
a active selection. Thanks to rv3.