### PR TITLE
Fixed the docking issue when the user has multiple monitors

### DIFF
--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -341,7 +341,8 @@ make_splash(Canvas, Imgs) ->
 %%%%%%%%%%%%%%%%%%%%%%%
 
 handle_event(#wx{obj=Win, event=#wxMove{}}, State) ->
-    #wxMouseState{x=X,y=Y} = MS = wx_misc:getMouseState(),
+    MS = wx_misc:getMouseState(),
+    {X,Y} = wx_misc:getMousePosition(),
     %% io:format("Move ~p ~p ~p ~n", [Win, X,Y]),
     {noreply, preview_attach(stopped_moving(MS), {X,Y}, Win, State)};
 


### PR DESCRIPTION
Docking was not working in a multiple monitors layout. The MouseState function
didn't take them in account properly. For example, for a secundary monitor at
left the X coordinate less than 0 has a value like 4294997294 equivalent to -1
and 4294965376 equivantet to -1920.
The function getMousePosition() returns the proper values fixing the issue.

NOTE: Fixed the window docking feature for multiple monitors systems. Thanks to suzuki.