### PR TITLE
Fixed the wrong dialog location when user has multiple monitors

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -834,12 +834,13 @@ set_position(mouse, Dialog) ->
     {Wd, Hd} = wxWindow:getSize(Dialog),
     Ws = wxSystemSettings:getMetric(?wxSYS_SCREEN_X),
     Hs = wxSystemSettings:getMetric(?wxSYS_SCREEN_Y),
+    {XWw, YWw} = wxWindow:getScreenPosition(?GET(top_frame)),
     if (Xm+Wd) < Ws, (Ym+Hd) < Hs ->
-            wxWindow:move(Dialog, max(Xm-100, 0), max(Ym-50, 0));
+            wxWindow:move(Dialog, max(Xm-100, min(0,XWw)), max(Ym-50, min(0,YWw)));
        (Xm+Wd) < Ws ->
-            wxWindow:move(Dialog, max(Xm-100, 0), max(Hs-Hd-50, 0));
+            wxWindow:move(Dialog, max(Xm-100, min(0,XWw)), max(Hs-Hd-50, min(0,YWw)));
        (Ym+Hd) < Hs ->
-            wxWindow:move(Dialog, max(Ws-Wd-100, 0), max(Ym-50, 0));
+            wxWindow:move(Dialog, max(Ws-Wd-100, min(0,XWw)), max(Ym-50, min(0,YWw)));
        true ->
             io:format("~p ~p~n",[{Xm,Wd,Ws},{Ym,Hd,Hs}]),
             ok


### PR DESCRIPTION
Dialog windows would be displayed on the wrong screen location if the
user has a system with multple monitors. Because we don't have some
wxDisplay functions available in Erlang I did a workaround by using the
minimal coordinate of the window instead of zero. That is necessário
only if the display in use is placed on the left or top side of the
primary monitor - in these cases the coordinates has negative value.

NOTE: Fixed the wrong dialog location when user has multiple monitors.
Thanks to suzuki.