### PR TITLE
Moving objcts to a folder was crashing Wings3D

### DIFF
--- a/src/wings_obj.erl
+++ b/src/wings_obj.erl
@@ -268,7 +268,7 @@ we_from_obj(Obj, #we{name=Name0,perm=Perm0,pst=Pst0,light=Light0}=We) ->
                       Folder0 ->
                           Pst0;
                       _ ->
-                          gb_trees:update(?FOLDERS, Folder, Pst0)
+                          gb_trees:enter(?FOLDERS, Folder, Pst0)
                   end,
             We#we{name=Name,perm=Perm,pst=Pst,light=Light}
     end.


### PR DESCRIPTION
By default the object's pst doesn't have the ?FOLDERS key added and the
use of gb_trees:update/3 was causing the crash since it requires the key
to exists.

NOTE: Moving any object to a folder was causing a crash. Thanks to Hank.