### PR TITLE
Fixed the render code for 'View->Show->Image Plane'

### DIFF
--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -748,18 +748,19 @@ show_camera_image_plane() ->
 draw_camera_image_plane({Poly,{X1,Y1,X2,Y2}}) ->
     NoVs = byte_size(Poly) div 12,
     Draw =
-    fun() ->
-	wings_io:ortho_setup(),
-	gl:enable(?GL_BLEND),
-	gl:blendFunc(?GL_SRC_ALPHA, ?GL_ONE_MINUS_SRC_ALPHA),
-	gl:color4f(0.0, 0.4, 0.8, 0.5),
-	gl:drawArrays(?GL_QUADS, 0, NoVs),
-	gl:color3f(0.0, 0.4, 0.8),
-	gl:lineWidth(2.0),
-	gl:polygonMode(?GL_FRONT_AND_BACK, ?GL_LINE),
-	gl:rectf(X2, Y1, X1, Y2),
-	gl:flush()
-    end,
+        fun(RS) ->
+            wings_io:ortho_setup(),
+            gl:enable(?GL_BLEND),
+            gl:blendFunc(?GL_SRC_ALPHA, ?GL_ONE_MINUS_SRC_ALPHA),
+            gl:color4f(0.0, 0.4, 0.8, 0.5),
+            gl:drawArrays(?GL_QUADS, 0, NoVs),
+            gl:color3f(0.0, 0.4, 0.8),
+            gl:lineWidth(2.0),
+            gl:polygonMode(?GL_FRONT_AND_BACK, ?GL_LINE),
+            gl:rectf(X2, Y1, X1, Y2),
+            gl:flush(),
+            RS
+        end,
     wings_vbo:new(Draw, Poly).
 
 clip(Ox, Oy, Ow, Px, Py, Pw, Char, Viewport) ->

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -32,7 +32,7 @@ menu() ->
      [{?__(1,"Ground Plane"),show_groundplane,?__(2,"Show the ground plane"),
        crossmark(show_groundplane)},
       {?__(3,"Axes"),show_axes,?__(4,"Show the coordinate axes"),crossmark(show_axes)},
-      {?__(78,"Image Plane"),show_cam_imageplane,?__(79,"Show the camera image plane"),crossmark(show_cam_imageplane)},
+      {?__(78,"Camera Image Plane"),show_cam_imageplane,?__(79,"Show the camera image plane"),crossmark(show_cam_imageplane)},
       {?__(48,"Show Info Text"),show_info_text,
        ?__(49,"Show an informational text at the top of this Geometry window"),
        crossmark(show_info_text)},


### PR DESCRIPTION
The option to show the 'Camera Image Plane' was causing Wings3D to crash.