### PR TITLE
Added support to vertex colors when importing files

### DIFF
--- a/src/wings_color.erl
+++ b/src/wings_color.erl
@@ -15,7 +15,7 @@
 -export([init/0,choose/1,choose/2,choose/3,
 	 share/1,store/1,average/1,average/2,mix/3,white/0,
 	 rgb_to_hsv/1,rgb_to_hsv/3,hsv_to_rgb/1,hsv_to_rgb/3,
-	 rgb3bv/1, rgb4bv/1, rgb3fv/1, rgb4fv/1,
+	 rgba_to_rgb/1, rgb3bv/1, rgb4bv/1, rgb3fv/1, rgb4fv/1,
 	 def_palette/0
 	]).
 
@@ -203,6 +203,9 @@ hsv_to_rgb(H, S, V) ->
 	    {B,R,G} = convert_hsv(H-240.0,V,Min),
 	    {R,G,B}
     end.
+
+rgba_to_rgb({R,G,B,_}) -> {R,G,B};
+rgba_to_rgb({_,_,_}=RGB) -> RGB.
 
 convert_hsv(H,V,Min) when H =< 60.0 ->
     Mean = Min + H*(V-Min)/(120.0-H),

--- a/src/wings_va.erl
+++ b/src/wings_va.erl
@@ -15,8 +15,8 @@
 	 any_attributes/1,any_colors/1,any_uvs/1,
 	 face_attr/3,face_attr/4,face_pos_attr/4,fold/5,set_face_attrs/3,
 	 face_mixed_attrs/2,
-	 all/2,edge_attrs/3,edge_attrs/4,set_edge_attrs/4,
-	 set_both_edge_attrs/4,set_edge_uvs/2,set_edge_colors/2,del_edge_attrs/2,
+	 all/2,edge_attrs/3,edge_attrs/4,set_edge_attrs/4,set_both_edge_attrs/4,
+	 set_edge_attrs/2,set_edge_uvs/2,set_edge_colors/2,del_edge_attrs/2,
 	 set_edge_color/4,
 	 vtx_attrs/2,vtx_attrs/3,attr/2,new_attr/2,average_attrs/1,average_attrs/2,
 	 set_vtx_face_uvs/4,
@@ -270,6 +270,15 @@ set_edge_attrs(Edge, Face, Attr, #we{es=Etab,lv=Lva,rv=Rva}=We) ->
 set_both_edge_attrs(Edge, LeftAttr, RightAttr, #we{lv=Lva,rv=Rva}=We) ->
     We#we{lv=aset(Edge, LeftAttr, Lva),
 	  rv=aset(Edge, RightAttr, Rva)}.
+
+%% set_both_edge_attrs([{Edge,LeftUV,RightUV,LeftVC,RightVC}, We0) -> We
+%%  Assign UV coordinates and vertex's color to the edges in the list.
+%%
+-spec set_edge_attrs([{edge_num(),all_attributes(),all_attributes(),
+			    all_attributes(),all_attributes()}], #we{}) -> #we{}.
+set_edge_attrs(List, #we{lv=Lva0,rv=Rva0}=We) ->
+    {Lva,Rva} = set_edge_attrs_1(List, Lva0, Rva0),
+    We#we{lv=Lva,rv=Rva}.
 
 %% set_edge_uvs([{Edge,LeftUV,RightUV}, We0) -> We
 %%  Assign UV coordinates to the edges in the list.
@@ -771,6 +780,14 @@ set_edge_colors_1([{Edge,LeftUV,RightUV}|T], Lva0, Rva0) ->
     Rva = set_color(Edge, RightUV, Rva0),
     set_edge_colors_1(T, Lva, Rva);
 set_edge_colors_1([], Lva, Rva) -> {Lva,Rva}.
+
+set_edge_attrs_1([{Edge,LeftUV,RightUV,LeftVC,RightVC}|T], Lva1, Rva1) ->
+    Lva0 = set_uv(Edge, LeftUV, Lva1),
+    Lva = set_color(Edge, LeftVC, Lva0),
+    Rva0 = set_uv(Edge, RightUV, Rva1),
+    Rva = set_color(Edge, RightVC, Rva0),
+    set_edge_attrs_1(T, Lva, Rva);
+set_edge_attrs_1([], Lva, Rva) -> {Lva,Rva}.
 
 set_color(Edge, Color, Tab) ->
     case aget(Edge, Tab) of

--- a/src/wings_we_build.erl
+++ b/src/wings_we_build.erl
@@ -86,7 +86,7 @@ build_and_fix_holes(_, _) ->
 
 build_rest(Es, Fs, Vs, HardEdges) ->
     Htab = vpairs_to_edges(HardEdges, Es),
-    {Vct0,Etab,Ftab0,UvTab} = build_tables(Es),
+    {Vct0,Etab,Ftab0,UvVcTab} = build_tables(Es),
     Ftab = build_faces(Ftab0),
     Vct = array:from_orddict(incident_tab(Vct0)),
     Vpos = number_vertices(Vs, 0, []),
@@ -99,7 +99,7 @@ build_rest(Es, Fs, Vs, HardEdges) ->
 		     wings_util:array_greatest_key(Etab)+1
 	     end,
     We0 = #we{next_id=NextId,es=Etab,fs=Ftab,vc=Vct,vp=Vpos,he=Htab},
-    We = wings_va:set_edge_uvs(UvTab, We0),
+    We = wings_va:set_edge_attrs(UvVcTab, We0),
     assign_materials(Fs, We).
 
 assign_materials([L|_], We) when is_list(L) -> We;
@@ -133,33 +133,38 @@ build_edges(Fs) ->
 build_half_edges(Fs) ->
     build_half_edges(Fs, 0, []).
 
-build_half_edges([{_Material,Vs,Tx}|Fs], Face, Eacc0) ->
-    build_half_edges_1(Vs, Tx, Fs, Face, Eacc0);
-build_half_edges([{_Material,Vs}|Fs], Face, Eacc0) ->
-    build_half_edges_1(Vs, tx_filler(Vs), Fs, Face, Eacc0);
-build_half_edges([Vs|Fs], Face, Eacc0) ->
-    build_half_edges_1(Vs, tx_filler(Vs), Fs, Face, Eacc0);
+build_half_edges([{_Material,Vs,none,Vc}|Fs], Face, Eacc0) ->	% imported with vertex color only
+    build_half_edges_1(Vs, tx_filler(Vs), Vc, Fs, Face, Eacc0);
+build_half_edges([{_Material,Vs,Tx,none}|Fs], Face, Eacc0) ->	% imported with textures only
+    build_half_edges_1(Vs, Tx, tx_filler(Vs), Fs, Face, Eacc0);
+build_half_edges([{_Material,Vs,Tx,Vc}|Fs], Face, Eacc0) ->	% imported with textures and vertex color
+    build_half_edges_1(Vs, Tx, Vc, Fs, Face, Eacc0);
+build_half_edges([{_Material,Vs}|Fs], Face, Eacc0) ->	% imported without textures or vertex color
+    build_half_edges_1(Vs, tx_filler(Vs), tx_filler(Vs), Fs, Face, Eacc0);
+build_half_edges([Vs|Fs], Face, Eacc0) ->	% new primitives
+    build_half_edges_1(Vs, tx_filler(Vs), tx_filler(Vs), Fs, Face, Eacc0);
 build_half_edges([], _Face, HalfEdges) -> HalfEdges.
 
-build_half_edges_1(Vs, UVs, Fs, Face, Acc0) ->
-    Vuvs = zip(Vs, UVs),
+build_half_edges_1(Vs, UVs, VCs, Fs, Face, Acc0) ->
+    UvsVcs = zip(UVs,VCs),
+    Vuvs = zip(Vs, UvsVcs),
     Pairs = pairs(Vuvs),
     Acc = build_face_edges(Pairs, Face, Acc0),
     build_half_edges(Fs, Face+1, Acc).
 
-build_face_edges([{Pred,_}|[{E0,{_UVa,UVb}},{Succ,_}|_]=Es], Face, Acc0) ->
+build_face_edges([{Pred,_}|[{E0,{{_UVa,UVb},{_VCa,VCb}}},{Succ,_}|_]=Es], Face, Acc0) ->
     Acc = case E0 of
 	      {Vs,Ve}=Name when Vs < Ve ->
-		  enter_half_edge(right, Name, Face, Pred, Succ, UVb, Acc0);
+		  enter_half_edge(right, Name, Face, Pred, Succ, {UVb,VCb}, Acc0);
 	      {Vs,Ve} when Ve < Vs ->
 		  Name = {Ve,Vs},
-		  enter_half_edge(left, Name, Face, Pred, Succ, UVb, Acc0)
+		  enter_half_edge(left, Name, Face, Pred, Succ, {UVb,VCb}, Acc0)
 	  end,
     build_face_edges(Es, Face, Acc);
 build_face_edges([_,_], _Face, Acc) -> Acc.
 
-enter_half_edge(Side, Name, Face, Pred, Succ, UV,Tab0) ->
-    Rec = {Face,UV,edge_name(Pred),edge_name(Succ)},
+enter_half_edge(Side, Name, Face, Pred, Succ, UVVC,Tab0) ->
+    Rec = {Face,UVVC,edge_name(Pred),edge_name(Succ)},
     [{Name,{Side,Rec}}|Tab0].
 
 pairs(Vs) ->
@@ -210,10 +215,10 @@ build_tables(Edges) ->
     Emap = make_edge_map(Edges),
     build_tables(Edges, Emap, [], [], [], []).
 
-build_tables([H|T], Emap, Vtab0, Etab0, Ftab0, UvTab0) ->
+build_tables([H|T], Emap, Vtab0, Etab0, Ftab0, UvVcTab0) ->
     {{Vs,Ve},{Edge,{Ldata,Rdata}}} = H,
-    {Lf,LUV,Lpred,Lsucc} = Ldata,
-    {Rf,RUV,Rpred,Rsucc} = Rdata,
+    {Lf,{LUV,LVC},Lpred,Lsucc} = Ldata,
+    {Rf,{RUV,RVC},Rpred,Rsucc} = Rdata,
     Erec = #edge{vs=Vs,ve=Ve,lf=Lf,rf=Rf,
 		 ltpr=edge_num(Lf, Lpred, Emap),
 		 ltsu=edge_num(Lf, Lsucc, Emap),
@@ -222,14 +227,14 @@ build_tables([H|T], Emap, Vtab0, Etab0, Ftab0, UvTab0) ->
     Etab = [{Edge,Erec}|Etab0],
     Ftab = [{Lf,Edge},{Rf,Edge}|Ftab0],
     Vtab = [{Vs,Edge},{Ve,Edge}|Vtab0],
-    UvTab = case {LUV,RUV} of
-		{none,none} -> UvTab0;
-		{_,_} -> [{Edge,LUV,RUV}|UvTab0]
+    UvVcTab = case {LUV,RUV,LVC,RVC} of
+		{none,none,none,none} -> UvVcTab0;
+		{_,_,_,_} -> [{Edge,LUV,RUV,LVC,RVC}|UvVcTab0]
 	    end,
-    build_tables(T, Emap, Vtab, Etab, Ftab, UvTab);
-build_tables([], _Emap, Vtab, Etab0, Ftab, UvTab) ->
+    build_tables(T, Emap, Vtab, Etab, Ftab, UvVcTab);
+build_tables([], _Emap, Vtab, Etab0, Ftab, UvVcTab) ->
     Etab = array:from_orddict(reverse(Etab0)),
-    {Vtab,Etab,Ftab,UvTab}.
+    {Vtab,Etab,Ftab,UvVcTab}.
 
 make_edge_map(Es) ->
     make_edge_map(Es, []).
@@ -381,9 +386,9 @@ elim_vtx_map([], _, Acc) ->
 elim_renum_vs([{Mat,Vs0}|Faces], [{Face,DupVs}|ToDo], Face, VtxMap, Acc) ->
     Vs = elim_renum_vs_1(Vs0, DupVs, VtxMap),
     elim_renum_vs(Faces, ToDo, Face+1, VtxMap, [{Mat,Vs}|Acc]);
-elim_renum_vs([{Mat,Vs0,Tx}|Faces], [{Face,DupVs}|ToDo], Face, VtxMap, Acc) ->
+elim_renum_vs([{Mat,Vs0,Tx,Vc}|Faces], [{Face,DupVs}|ToDo], Face, VtxMap, Acc) ->
     Vs = elim_renum_vs_1(Vs0, DupVs, VtxMap),
-    elim_renum_vs(Faces, ToDo, Face+1, VtxMap, [{Mat,Vs,Tx}|Acc]);
+    elim_renum_vs(Faces, ToDo, Face+1, VtxMap, [{Mat,Vs,Tx,Vc}|Acc]);
 elim_renum_vs([MatVs|Faces], ToDo, Face, VtxMap, Acc) ->
     elim_renum_vs(Faces, ToDo, Face+1, VtxMap, [MatVs|Acc]);
 elim_renum_vs([], [], _, _, Acc) -> reverse(Acc).


### PR DESCRIPTION
Changed the wings_we:build/2 to handle a #e3d_mesh{} that contains vertex
color information present in some imported files.
The '.obj' format doesn't supports vertex color natively, but others like
'.ply' and '.glTF' does.