### PR TITLE
Fixed the color control

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -569,8 +569,8 @@ get_curr_value(#in{type=dirpicker, wx=Ctrl}) ->
     wxDirPickerCtrl:getPath(Ctrl);
 get_curr_value(#in{type=fontpicker, wx=Ctrl}) ->
     wxFontPickerCtrl:getSelectedFont(Ctrl);
-get_curr_value(#in{type=color, data=Data}) ->
-    Data;
+get_curr_value(#in{type=color, wx=Ctrl}) ->
+    ww_color_ctrl:getColor(Ctrl);
 get_curr_value(#in{type=slider, wx=Ctrl, data={Convert,_}}) ->
     Convert(wxSlider:getValue(Ctrl));
 get_curr_value(#in{type=col_slider, data=Val}) ->


### PR DESCRIPTION
The color control was not getting its value updated back after the color
control dialog be closed. That was noticed primarily in lights dialogs.

The fix was in true a workaround. I tracked the values and everything is
working fine. The problem may be related to a multiple dialogs issue(??).
The control hook calls the set_value/3 which calls set_value_impl/3 that
should to be updateing the #in{data} with the new value, but this command:
true = ets:insert(Store, In#in{data=Val})
seems to be "ignored" since the data value when getting the dialog result
is still the default one (def).