### PR TITLE
Bevel command was craaching when a vertex which dived a edge

### DIFF
--- a/src/wings_vertex_cmd.erl
+++ b/src/wings_vertex_cmd.erl
@@ -205,10 +205,13 @@ bevel_1(VsSet, We0) ->
     Vs = gb_sets:to_list(VsSet),
     {We1,VecVs0,WeTrans,Fs0} = bevel_vertices(Vs, VsSet, We0, We0, [], [], []),
     {VecVs,Limit} = bevel_normalize(VecVs0),
-    Tv = {we,WeTrans,wings_drag:translate_fun(VecVs, We1)},
-    We = We1#we{temp={Limit,Tv}},
-    Fs = gb_sets:from_list(Fs0),
-    {We,Fs}.
+    case VecVs of
+	[] ->
+	    {We0, gb_sets:empty()};
+	_ ->
+	    Tv = {we,WeTrans,wings_drag:translate_fun(VecVs, We1)},
+	    {We1#we{temp={Limit,Tv}}, gb_sets:from_list(Fs0)}
+    end.
 
 bevel_vertices([V|Vs], VsSet, WeOrig, We0, Acc0, Facc, WeTrans0) ->
     Adj = adjacent(V, VsSet, WeOrig),


### PR DESCRIPTION
That was caused by the recents code updated wich now translate_fun is now has
a type definition that is requiring e3d_vec:vector() as paremeter. For the
situation like that we where passing a empty list as parameter.