### PR TITLE
Fixed the crash caused by Tighten in AutoUV window

### DIFF
--- a/src/wings_drag.erl
+++ b/src/wings_drag.erl
@@ -175,6 +175,8 @@ compose(Transforms) ->
 -spec translate_fun([{e3d_vec:vector(),vertices()}], #we{}) ->
                            {vertices(),vec_transform_fun()}.
 
+translate_fun([]=VecVs0, _) ->  %% a empty list can be generated in wings_vertex_cmd:tighten_vs
+    {VecVs0,translate_fun(VecVs0)};
 translate_fun([_|_]=VecVs0, #we{vp=Vtab}) ->
     SS = sofs:from_term(VecVs0, [{vec,[vertex]}]),
     FF = sofs:relation_to_family(SS),

--- a/src/wings_drag.erl
+++ b/src/wings_drag.erl
@@ -175,9 +175,7 @@ compose(Transforms) ->
 -spec translate_fun([{e3d_vec:vector(),vertices()}], #we{}) ->
                            {vertices(),vec_transform_fun()}.
 
-translate_fun([]=VecVs0, _) ->  %% a empty list can be generated in wings_vertex_cmd:tighten_vs
-    {VecVs0,translate_fun(VecVs0)};
-translate_fun([_|_]=VecVs0, #we{vp=Vtab}) ->
+translate_fun(VecVs0, #we{vp=Vtab}) ->
     SS = sofs:from_term(VecVs0, [{vec,[vertex]}]),
     FF = sofs:relation_to_family(SS),
     FU = sofs:family_union(FF),

--- a/src/wings_vertex_cmd.erl
+++ b/src/wings_vertex_cmd.erl
@@ -205,13 +205,10 @@ bevel_1(VsSet, We0) ->
     Vs = gb_sets:to_list(VsSet),
     {We1,VecVs0,WeTrans,Fs0} = bevel_vertices(Vs, VsSet, We0, We0, [], [], []),
     {VecVs,Limit} = bevel_normalize(VecVs0),
-    case VecVs of
-	[] ->
-	    {We0, gb_sets:empty()};
-	_ ->
-	    Tv = {we,WeTrans,wings_drag:translate_fun(VecVs, We1)},
-	    {We1#we{temp={Limit,Tv}}, gb_sets:from_list(Fs0)}
-    end.
+    Tv = {we,WeTrans,wings_drag:translate_fun(VecVs, We1)},
+    We = We1#we{temp={Limit,Tv}},
+    Fs = gb_sets:from_list(Fs0),
+    {We,Fs}.
 
 bevel_vertices([V|Vs], VsSet, WeOrig, We0, Acc0, Facc, WeTrans0) ->
     Adj = adjacent(V, VsSet, WeOrig),


### PR DESCRIPTION
The problem was affecting only the Tighten command for the AutoUV window and
it was related to an empty list of vertex passed to drag module.
As I could check, it was introduced after the changes made to wings_drag module
in versin 2.1.6.

NOTE: Fixed the crash caused by Tighten in AutoUV window. Thanks to Hank.