### PR TITLE
Fixed an crash caused by no float value imported

### DIFF
--- a/plugins_src/import_export/wpc_gltf.erl
+++ b/plugins_src/import_export/wpc_gltf.erl
@@ -901,8 +901,8 @@ make_mat(#{name:=Name}=Mat, GLTF, Dir) ->
             {Mtx,Rtx} = split_tx(get_texture(metallicRoughnessTexture, Pbr, GLTF), Dir),
             MetalTx = {metallic, Mtx},
             RoughTx = {roughness, Rtx},
-            MetalF = maps:get(metallicFactor, Pbr, 1.0),
-            RoughF = maps:get(roughnessFactor, Pbr, 0.9)
+            MetalF = float(maps:get(metallicFactor, Pbr, 1.0)),
+            RoughF = float(maps:get(roughnessFactor, Pbr, 0.9))
     end,
 
     NormalTx = {normal, get_texture(normalTexture, Mat, GLTF)},


### PR DESCRIPTION
It was noticed during some test using the projects provided by Chronos
that some files may have integer values instead of the float ones as
expected by the importer.