### PR TITLE
A try to fix the light issue for render exporters

### DIFF
--- a/plugins_src/import_export/wpc_kerky.erl
+++ b/plugins_src/import_export/wpc_kerky.erl
@@ -267,7 +267,7 @@ do_export(Attr, Op, Exporter, St) when is_list(Attr) ->
     Dir1 = export_transform_vec(Dir),
     Up1 = export_transform_vec(Up),
     CameraInfo = #camera_info{pos=Pos1, dir=Dir1, up=Up1, fov=Fov, az=Azimuth, el=Elevation, track=Track, dist=Dist},
-    CL_Attr = [CameraInfo, {lights, wpa:lights(St)}, {operation, Op} | Attr],
+    CL_Attr = [CameraInfo, {lights, wpa:lights_bc(St)}, {operation, Op} | Attr],
 
     case Op of
         render -> R_Attr = [{?TAG_RENDER, true} | CL_Attr];

--- a/plugins_src/import_export/wpc_pov.erl
+++ b/plugins_src/import_export/wpc_pov.erl
@@ -308,7 +308,7 @@ do_export(Attr, Op, Exporter, St) when is_list(Attr) ->
     Dir1 = export_transform_vec(Dir),
     Up1 = export_transform_vec(Up),
     CameraInfo = #camera_info{pos = Pos1, dir = Dir1, up = Up1, fov = Fov},
-    CL_Attr = [CameraInfo, {lights, wpa:lights(St)}, {operation, Op} | Attr],
+    CL_Attr = [CameraInfo, {lights, wpa:lights_bc(St)}, {operation, Op} | Attr],
 
     case Op of
         render -> R_Attr = [{?TAG_RENDER, true} | CL_Attr];

--- a/plugins_src/import_export/wpc_rib.erl
+++ b/plugins_src/import_export/wpc_rib.erl
@@ -139,7 +139,7 @@ do_render(Attr0, Engine, St) ->
 		    [{render_file,RendFile}|Attr0];
 		preview -> Attr0
 	    end,
-    Ls = wpa:lights(St),
+    Ls = wpa:lights_bc(St),
     Attr2 = [{lights,Ls},{tmp_render,Engine}|Attr1],
     Attr = add_attr(Engine, Attr2),
     wpa:export(none, render_fun(Attr), St).
@@ -231,7 +231,7 @@ do_export(Ask, Op, _Exporter, _St) when is_atom(Ask) ->
 	       end);
 do_export(Attr0, _Op, Exporter, St) when is_list(Attr0) ->
     set_pref(Attr0),
-    Ls = wpa:lights(St),
+    Ls = wpa:lights_bc(St),
     Attr = [{lights,Ls},{tmp_render,none}|Attr0],
     Exporter(props(), export_fun(Attr)).
 

--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -628,7 +628,7 @@ do_export(Op, Props0, Attr0, St0) ->
     Props = [{subdivisions,SubDiv}|Props0],
     [{Pos,Dir,Up},Fov] = wpa:camera_info([pos_dir_up,fov]),
     CameraInfo = #camera_info{pos=Pos,dir=Dir,up=Up,fov=Fov},
-    Attr = [CameraInfo,{lights,wpa:lights(St0)}|Attr0],
+    Attr = [CameraInfo,{lights,wpa:lights_bc(St0)}|Attr0],
     ExportFun =
         fun (Filename, Contents) ->
             case catch export(Attr, Filename, Contents) of

--- a/src/wpa.erl
+++ b/src/wpa.erl
@@ -37,7 +37,7 @@
 	 face_dissolve/2,face_dissolve_complement/2,
 	 edge_loop_vertices/2,
 	 obj_name/1,obj_id/1,
-	 camera_info/1,lights/1,import_lights/2,
+	 camera_info/1,lights/1,lights_bc/1,import_lights/2,
 	 image_formats/0,image_read/1,image_write/1,
 	 vm_freeze/1,
 	 triangulate/1,triangulate/2,quadrangulate/1,quadrangulate/2,
@@ -568,7 +568,18 @@ camera_info(As) ->
 %%%
 
 lights(St) ->
-    case wings_light:export(St) of
+    lights_0(St,false).
+
+lights_bc(St) ->
+    lights_0(St,true).
+
+lights_0(St,BC) when is_boolean(BC) ->
+    Lights =
+	case BC of
+	    false -> wings_light:export(St);
+	    true -> wings_light:export_bc(St)
+	end,
+    case Lights of
 	[] -> wings_light:export_camera_lights();
 	L -> L
     end.


### PR DESCRIPTION
I hope this kind of workaround would be accept of a better solution find.
Without it it's impossible to render any scene using the current
implementation of Wings3D. By removing (or renaming) the lights isn't 
interesting since it's useful to tweak them outside Wings3D or in its own UI 
(as Kerkythea) as well as identify them to update back the information to the
Wings3D project.

NOTE: Fixed the render crash if a light is present. Thanks to oort.