### PR TITLE
Fixed a crash caused by wings_view during vectors input

### DIFF
--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -1104,7 +1104,8 @@ views_jump(J, St, CurrentView, Views) ->
 	{J,J} ->
 	    {View,_} = element(J, Views),
 	    set_current(View),
-	    wings_wm:dirty();
+	    wings_wm:dirty(),
+	    St;
 	{J,_} ->
 	    {View,_} = element(J, Views),
 	    set_current(View),


### PR DESCRIPTION
When jumping to a saved view during a vector input operation and the
current saved view was the same as the current one, the code was returning
a 'keep' value instead of the non changed #st{} - which was the expected
value by the wings_vec module.

Reported here: http://www.wings3d.com/forum/showthread.php?tid=2749

NOTE: Changing to a saved view in the middle of a vector input operation
was causing Wings3D to crash. Thanks to Hank.