### PR TITLE
Selection groups has not been saved for hidden/locked objects

### DIFF
--- a/src/wings_ff_wings.erl
+++ b/src/wings_ff_wings.erl
@@ -1294,7 +1294,7 @@ collect_sel(#st{selmode=Mode,sel=Sel0,ssels=Ssels}=St) ->
 
 collect_sel_groups([{{Mode,Name},Sel}|Gs], St, Acc0) ->
     Acc = [{Id,{Mode,gb_sets:to_list(Elems),{selection_group,Name}}} ||
-	      {Id,Elems} <- wings_sel:valid_sel(Sel, Mode, St)] ++ Acc0,
+	      {Id,Elems} <- wings_sel:valid_sel_groups(Sel, Mode, St)] ++ Acc0,
     collect_sel_groups(Gs, St, Acc);
 collect_sel_groups([], _, Acc) -> Acc.
 

--- a/src/wings_sel.erl
+++ b/src/wings_sel.erl
@@ -20,7 +20,7 @@
          map_update_sel/2,map_update_sel/3,
 	 update_sel/2,update_sel/3,update_sel_all/2,
          fold_obj/3,fold/3,dfold/4,mapfold/3,
-	 new_sel/3,make/3,valid_sel/1,valid_sel/3,
+	 new_sel/3,make/3,valid_sel/1,valid_sel/3,valid_sel_groups/3,
          clone/2,clone/3,combine/2,combine/3,merge/2,
 	 center/1,center_vs/1,
 	 bbox_center/1,bounding_box/1,
@@ -514,6 +514,26 @@ valid_sel(Sel0, Mode, #st{shapes=Shapes}) ->
 			    end
 		    end
 	    end, [], Sel0),
+    reverse(Sel).
+
+-spec valid_sel_groups(SelIn, Mode, #st{}) -> SelOut when
+    Mode :: mode(),
+    SelIn :: [{item_id(),item_set()}],
+    SelOut :: [{item_id(),item_set()}].
+
+valid_sel_groups(Sel0, Mode, #st{shapes=Shapes}) ->	% allow wings to save any selection groups
+    Sel = foldl(
+	fun({Id,Items0}, A) ->
+	    case gb_trees:lookup(Id, Shapes) of
+		none -> A;
+		{value,We} ->
+		    Items = validate_items(Items0, Mode, We),
+		    case gb_sets:is_empty(Items) of
+			false -> [{Id,Items}|A];
+			true -> A
+		    end
+	    end
+	end, [], Sel0),
     reverse(Sel).
 
 -spec select_object(obj_id(), #st{}) -> #st{}.


### PR DESCRIPTION
The selection validation shoud not to ignore hidden/locked object when
we are saving them to Wings3d file. As it's a special case I created a
new function to handle that.

Reported here: http://www.wings3d.com/forum/showthread.php?tid=2756

NOTE: Selection groups has not been saved for hidden/locked objects.
Thanks to Hank.