### PR TITLE
Fixed the marque selection when an area light was present (face mode)

### DIFF
--- a/plugins_src/accel/wpc_pick.erl
+++ b/plugins_src/accel/wpc_pick.erl
@@ -36,7 +36,7 @@
 %%                Graphics Gems.
 %%
 -module(wpc_pick).
--export([init/0,pick_matrix/5,matrix/2,cull/1,front_face/1,
+-export([init/0,pick_matrix/5,matrix/2,cull/1,culling/0,front_face/1,
 	 faces/2,vertices/1,edges/1]).
 
 %% Comment out the following line to use the pure Erlang
@@ -108,6 +108,9 @@ cull(true) ->
 	true -> ok;
 	_ -> drv_cull(1)
     end.
+
+culling() ->
+    get({?MODULE,cull}) =:= true.
 
 %% front_face(ccw|cw)
 %%  Define the vertex order for front facing triangles.

--- a/src/wings_pick.erl
+++ b/src/wings_pick.erl
@@ -968,9 +968,10 @@ do_dlo_pick(D=#dlo{vab=#vab{face_vs=none}}, St, OneHit, Ms, Acc) ->
     do_dlo_pick(wings_draw_setup:work(D, St), St, OneHit, Ms, Acc);
 do_dlo_pick(#dlo{mirror=none,src_we=#we{id=Id}=We}=D, _, OneHit, _Ms, Acc)
   when ?IS_AREA_LIGHT(We) ->
+    Cull = wpc_pick:culling(),
     wpc_pick:cull(false),
     Res = do_dlo_pick_0(Id, D, OneHit, Acc),
-    wpc_pick:cull(true),
+    wpc_pick:cull(Cull),
     Res;
 do_dlo_pick(#dlo{mirror=none,open=Open,src_we=#we{id=Id}}=D, _, OneHit, _Ms, Acc) ->
     case wings_pref:get_value(show_backfaces) of


### PR DESCRIPTION
That is another asleep bug, present since 2.0
Reported here: http://www.wings3d.com/forum/showthread.php?tid=2758

NOTE: If a area light is present only the faces facing the camera can get
selected by marquee selection. Thanks Hank.