### PR TITLE
Workaround to a hard crash when closing a non registere window

### DIFF
--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -401,7 +401,12 @@ handle_event(#wx{obj=Obj, event=#wxClose{}}, #state{windows=Wins}=State) ->
 	    catch _:_ ->
 		    wings_wm:psend(Name, close),
 		    {noreply, State}
-	    end
+	    end;
+	_ ->
+	    ?dbg("\nUnexpected window closing\n\tObj: ~p\n\tWins: ~p\n",[Obj,Wins]),
+	    wings_u:message("Unexpected window closing.\n" ++
+			    "Please check the log window and report the information there."),
+	    {noreply, State}
     end;
 handle_event(_Ev, State) ->
     %% io:format("~p:~p Got unexpected event ~p~n", [?MODULE,?LINE, _Ev]),


### PR DESCRIPTION
It was obseved a crash in wings_frame module when handling the #wxClose event
which was unexpected and means an unhandled #wx{obj} is firing this event.
As a workaroound we are going to check for that and display some information
that would help us to know what is that object and how to permanently to fix
the crash cause.

Reported here: http://www.wings3d.com/forum/showthread.php?tid=2733

NOTE: Wings3D was crashing unexpected in module wings_frame. It was add a
workaround and some information to help us to find the cause. Thanks to  Hank