### PR TITLE
Diffuse texture with alpha channel was not drawing transparency

### DIFF
--- a/shaders/lib_base.glsl
+++ b/shaders/lib_base.glsl
@@ -38,7 +38,7 @@ vec4 SRGBtoLINEAR(vec4 srgbIn)
 {
     vec3 bLess = step(vec3(0.04045),srgbIn.xyz);
     vec3 linOut = mix( srgbIn.xyz/vec3(12.92), pow((srgbIn.xyz+vec3(0.055))/vec3(1.055),vec3(2.4)), bLess );
-    return vec4(linOut,srgbIn.w);;
+    return vec4(linOut,srgbIn.w);
 }
 
 PBRInfo calc_views(vec3 Norm, vec3 View, vec3 Ligth)

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -597,8 +597,20 @@ is_mat_transparent(Mat) ->
     Trans = lists:any(fun({diffuse,{_,_,_,Alpha}}) when Alpha < 1.0 -> true;
                          (_) -> false
                       end, OpenGL),
+    TransTx =
+        case proplists:get_value(maps, Mat, undefined) of
+            undefined ->
+                false;
+            Maps ->
+                case proplists:get_value(diffuse,Maps,undefined) of
+                    undefined -> false ;
+                    DiffMap ->
+                        #e3d_image{bytes_pp=Bpp} = wings_image:info(DiffMap),
+                        Bpp == 4
+                end
+        end,
     %% Trans orelse proplists:is_defined(diffuse, prop_get(maps, Mat)).
-    Trans.
+    Trans or TransTx.
 
 %% needed_attributes(We, St) -> [Attr]
 %%     Attr = color|uv|tangent


### PR DESCRIPTION
It was forgotten to check for alpha channel in diffuse texture before
prepare the object for drawing.

NOTE: Alpha channel of a diffuse texture was drawing in black. Thanks to tkbd