### PR TITLE
Changed default setting for 'Transp Refraction' to 'false'

### DIFF
--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -172,7 +172,7 @@ key(Key) -> {key,?KEY(Key)}.
 -define(DEF_CLAMP_RGB, true).
 -define(DEF_AA_FILTER_TYPE, box).
 -define(DEF_TRANSPARENT_SHADOWS, false).
--define(DEF_BACKGROUND_TRANSP_REFRACT, true).
+-define(DEF_BACKGROUND_TRANSP_REFRACT, false).
 -define(DEF_SHADOW_DEPTH, 2).
 -define(DEF_RAYDEPTH, 12).
 -define(DEF_BIAS, 0.001).


### PR DESCRIPTION
The default value (true) was causing the background to not be rendered.
In accord with oort that setting can render right only with Yafaray versions
prior to E1.0.0.

To avoid users to get the render issue newest versions we decided to set its
default value to 'false'.