### PR TITLE
Fixed the wrong location for uv segmentation submenu.

### DIFF
--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -356,7 +356,9 @@ popup_event_handler({click, Id, Click, Ns}, {Parent,Owner}=Own, Entries0) ->
     case popup_result(lists:keyfind(Id, 2, Entries0), Click, Ns, Owner) of
 	pop -> pop;
 	{submenu, Names, Menus, MagnetClick} ->
-	    {_, X, Y} = wings_io:get_mouse_state(),
+	    {_, X0, Y0} = wings_io:get_mouse_state(),
+	    Pos = wxWindow:screenToClient(wings_wm:this_win(), {X0,Y0}),
+	    {X,Y} = wxWindow:clientToScreen(wings_wm:this_win(), Pos),
 	    Entries = wx_popup_menu(Parent, {X,Y}, Names, Menus, MagnetClick, Owner),
 	    {replace, fun(Ev) -> popup_event_handler(Ev, Own, Entries) end}
     end;


### PR DESCRIPTION
For some strange reasion the Y coordinate returned by mouse_get_state/1 when
a submenu needed to be shown was getting a value greater than ~4000000 instead
of a lower negative value for the layout where the second monitor is up or left
to the first one.
But, for some reason, converting it to Client and back to Screen fix the
coordinate value and the menu is shown in the right place.

NOTE: The submenu in 'AutoUV Segmentating' was shown in the wrong display for
multiple monitors layout. Thanks to OXO.