### PR TITLE
Fixed wrong behaviour when using Material->Select option

### DIFF
--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -215,12 +215,14 @@ selected_items(Mode, Mat, #we{fs=Ftab}=We) ->
     case keyfind(Mat, 1, MatFaces) of
 	false ->
 	    gb_sets:empty();
+        _ when Mode =:= body ->
+            gb_sets:singleton(0);
 	{Mat,FaceInfoList} ->
 	    Fs = [F || {F,_} <- FaceInfoList, F >= 0],
             SelItems = case Mode of
                            vertex -> wings_face:to_vertices(Fs, We);
                            edge -> wings_face:to_edges(Fs, We);
-                           _ -> Fs
+                           face -> Fs
                        end,
             gb_sets:from_ordset(SelItems)
     end.


### PR DESCRIPTION
Bug reported here: http://www.wings3d.com/forum/showthread.php?tid=2789

NOTE: Select by Material in Outliner window was not working in accord when in
body selection mode. Thanks Hank.