### PR TITLE
The UI color customization was not working properlly

### DIFF
--- a/src/wings.erl
+++ b/src/wings.erl
@@ -802,6 +802,7 @@ command_1({edit,{preferences,Pref}}, St) ->
 command_1({edit,{theme,Theme}}, St) ->
     wings_pref:pref({load,Theme,St}),
     wings_frame:update_theme(),
+    wings_status:update_theme(),
     keep;
 
 %% Select menu.

--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -571,9 +571,13 @@ terminate_frame(_Ev, CB) ->
 update_active(Name, #state{active=Prev, windows=#{ch:=Root}}=State) ->
     ABG = wings_color:rgb4bv(wings_pref:get_value(title_active_color)),
     PBG = wings_color:rgb4bv(wings_pref:get_value(title_passive_color)),
+    TFG = wings_color:rgb4bv(wings_pref:get_value(title_text_color)),
     try
 	#win{bar={PBar,_}} = find_win(Prev, Root),
 	_ = wxWindow:getSize(PBar), %% Sync to check PBar validity
+	PChildren = wxWindow:getChildren(PBar),
+	[wxWindow:setForegroundColour(PChild, TFG) || PChild <- PChildren,
+	 wx:getObjectType(PChild) == wxWindow],
 	wxWindow:setBackgroundColour(PBar, PBG),
 	wxWindow:refresh(PBar)
     catch _:_ -> ignore
@@ -582,6 +586,9 @@ update_active(Name, #state{active=Prev, windows=#{ch:=Root}}=State) ->
 	false ->
 	    State#state{active=undefined};
 	#win{bar={ABar,_}} ->
+	    AChildren = wxWindow:getChildren(ABar),
+	    [wxWindow:setForegroundColour(AChild, TFG) || AChild <- AChildren,
+	     wx:getObjectType(AChild) == wxWindow],
 	    wxWindow:setBackgroundColour(ABar, ABG),
 	    wxWindow:refresh(ABar),
 	    State#state{active=Name}

--- a/src/wings_theme.erl
+++ b/src/wings_theme.erl
@@ -47,8 +47,6 @@ native_theme() ->
 		 {hard_edge_color,{1.0,0.5,0.0}},
 		 {info_background_color,{0.38,0.38,0.38,0.5}},
 		 {info_color,{1.0,1.0,1.0}},
-		 {info_line_bg,{0.33131360000000004,0.4,0.0}},
-		 {info_line_text,{1.0,1.0,1.0}},
 		 {masked_vertex_color,{0.5,1.0,0.0,0.8}},
 		 {material_default, {0.7898538076923077,0.8133333333333334,0.6940444444444445}},
 		 {neg_x_color,{0.8,0.8,0.8}},
@@ -80,6 +78,8 @@ native_theme() ->
 	      {outliner_geograph_hl,      highlight},
 	      {outliner_geograph_hl_text, highlighttext},
 	      {outliner_geograph_text, windowtext},
+	      {info_line_bg,c3dface},
+	      {info_line_text,windowtext},
 	      {title_active_color, activecaption},
 	      {title_passive_color,inactivecaption},
 	      {title_text_color,   captiontext}

--- a/src/wings_theme.erl
+++ b/src/wings_theme.erl
@@ -64,7 +64,7 @@ native_theme() ->
 		 {y_color,{0.37210077142857145,0.82,0.0}},
 		 {z_color,{0.0,0.3,0.8}}],
     UserIF = [{background_color, appworkspace},
-	      {dialog_color, desktop},
+	      {dialog_color, c3dface},
 	      {dialog_disabled, graytext},
 	      {dialog_text, windowtext},
 	      {menu_bar_bg,  menubar},


### PR DESCRIPTION
The Information Line was not using the customization settings and the
Active/Inactive window titles was not getting its text color updated
on-the-fly as the background was.
The titles uses a panel with a staticText for the caption which needs
to have its foreground color set.

obs: the bar still requires Wings3D to be restarted to get the color applied.