### PR TITLE
Fixed the plugin/patch installer

### DIFF
--- a/src/wings_plugin.erl
+++ b/src/wings_plugin.erl
@@ -335,17 +335,16 @@ erl_tar() -> %% Fool dialyzer the spec is wrong for erl_tar:table() in 20.0-20.2
 
 install_tar(Name) ->
     {ok,Files} = (erl_tar()):table(Name, [compressed]),
-    Content = install_verify_files(Files, Name),
-    {Type,Dest} = case Content of
-		    {plugin, _} -> {plugin, plugin_dir()};
-		    {_, patch} -> {patch, wings_start:patch_dir()}
-		end,
+    Type = install_verify_files(Files, Name),
+    Dest = case Type of
+		plugin -> plugin_dir();
+		patch -> wings_start:patch_dir()
+	    end,
     case erl_tar:extract(Name, [compressed,{cwd,Dest}]) of
-	ok ->
-	    if Type =:= patch -> wings_start:enable_patches();
-		true -> ok
-	    end;
-	{error, {_File, Reason}} -> 
+	ok when Type =:= patch ->
+	    wings_start:enable_patches();
+	ok -> ok;
+	{error, {_File, Reason}} ->
 	    wings_u:error_msg(?__(1,"Install of \"~s\" failed: ~p"),
 			      [filename:basename(Name),
 			       file:format_error(Reason)]);
@@ -357,27 +356,24 @@ install_tar(Name) ->
     {Type,Dest}.
 
 install_verify_files(Fs, Name) when is_list(Name) ->
-    install_verify_files(Fs, {{undefined,undefined},Name});
-install_verify_files(["/"++_|_], {_, Name}) ->
+    install_verify_files(Fs, Name, undefined).
+install_verify_files(["/"++_|_], Name, _) ->
     wings_u:error_msg(?__(1,"File \"~s\" contains a file with an absolute path"),
 		  [filename:basename(Name)]);
-install_verify_files([], {{undefined,undefined}, Name})->
+install_verify_files([], Name, undefined)->
     wings_u:error_msg(?__(2,"File \"~s\" does not contain any Wings patch or plug-in modules"),
 		      [filename:basename(Name)]);
-install_verify_files([], {Content, _}) ->
-    Content;
-install_verify_files([F|Fs], {{IsPlugin,IsPatch}=Content0, Name}) ->
-    Content =
-	case is_plugin(F) of
-	    false ->
-		case filename:extension(F) of
-		    ".beam" -> {IsPlugin,patch};
-		    _ -> Content0
-		end;
-	    true ->
-		{plugin,IsPatch}
-	end,
-    install_verify_files(Fs, {Content,Name}).
+install_verify_files([F|Fs], Name, Content) ->
+    case is_plugin(F) of
+	true ->
+	    %% plugin has priority, so we don't need to keep checking the other files
+	    plugin;
+	false ->
+	    case filename:extension(F) of
+		".beam" -> install_verify_files(Fs, Name, patch);
+		_ -> install_verify_files(Fs, Name, Content)
+	    end
+    end.
 
 is_plugin(Name) ->
     case filename:basename(Name) of


### PR DESCRIPTION
The plugin/patch installer was not allowing to pack patches into a .tar file.

OBS: It's important to remember that a '.tar' file must to contain or patches or
plugins, since its priority is for plugins (wpc_*) and mixing them will result
in patches files being unpacked under plugins folder.