### PR TITLE
Fixed the option to Save preferences subset

### DIFF
--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -715,6 +715,17 @@ update_menu(Menu, Item, Cmd0, Help) ->
     MI = case ets:lookup(wings_menus, Id) of
 	     [#menu{object=MO}] ->
 		 MO;
+	     [] when Menu =:= file, element(1, Item) =:= load_pref ->
+		 Names0 = build_names(Item, [Menu]),
+		 Names = lists:droplast(Names0),
+		 [#menu{object=CustomTheme, type=submenu}] = ets:match_object(wings_menus, #menu{name=Names, _ = '_'}),
+		 N  = wxMenu:getMenuItemCount(CustomTheme),
+		 MO = wxMenu:insert(CustomTheme, N, ?wxITEM_NORMAL, [{text, Cmd0}]),
+		 ME=#menu{name=build_command(Item,[Menu]), object=MO,
+			  wxid=Id, type=?wxITEM_NORMAL},
+		 true = ets:insert(wings_menus, ME),
+		 wxMenu:insertSeparator(CustomTheme, N),
+		 MO;
 	     [] when Menu =:= file, element(1, Item) =:= recent_file ->
 		 FileId = predefined_item(menu, Menu),
 		 [#menu{object=File, type=submenu}] = ets:lookup(wings_menus, FileId),

--- a/src/wings_pref.erl
+++ b/src/wings_pref.erl
@@ -74,7 +74,7 @@ latin1_file_to_unicode(PrefFile) ->
 get_dir() ->
     PFile = case get_value(pref_directory) of
 		undefined -> 
-		    File = get_pref_directory("backup_prefs.txt"),
+		    File = get_pref_directory("backup_prefs.pref"),
 		    set_value(pref_directory,File),
 		    File;
 		File -> File


### PR DESCRIPTION
Preferences subset was get a crash when we try to save a new one.
It looks like we broke it when switching from SDL to wxWidget library.

The code is very similar to the one for Recent Files, but cannot be the same.