### PR TITLE
Added missing info about geometry window to plugins

### DIFF
--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -347,6 +347,7 @@ is_geom() ->
     case this() of
       geom -> true;
       {geom,_} -> true;
+      {plugin, {_, geom}} -> true;
       _ -> false
     end.
 


### PR DESCRIPTION
It was already added support to plugins manage its "own" geometry window
in the function geom_below/1. This is also an important complementation.