### PR TITLE
Updated the calls to popup_meu/4 in order to use the new header

### DIFF
--- a/plugins_src/autouv/auv_seg_ui.erl
+++ b/plugins_src/autouv/auv_seg_ui.erl
@@ -129,7 +129,8 @@ seg_event_3(Ev, #seg{st=#st{selmode=Mode}}=Ss) ->
 		      [{?__(3,"Projection"),autouvmap},
 		       {?__(4,"Feature Detection"),feature}]}}|
 		    seg_mode_menu(Mode, Ss, seg_debug([]))],
-	    wings_menu:popup_menu(X, Y, auv_segmentation, Menu)
+	    Win = wings_wm:this_win(),
+	    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), auv_segmentation, Menu)
     end.
 
 -ifndef(DEBUG).

--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -408,7 +408,8 @@ command_menu(body, X, Y) ->
 				 ]}, 
 	     ?__(45,"Calculate new UVs with chosen algorithm")}
 	   ] ++ option_menu(),
-    wings_menu:popup_menu(X,Y, {auv,body}, Menu);
+    Win = wings_wm:this_win(),
+    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), {auv,body}, Menu);
 command_menu(face, X, Y) ->
     Scale = scale_directions(true),
     Move = move_directions(true),
@@ -419,7 +420,8 @@ command_menu(face, X, Y) ->
 	    {?__(521,"Project-Unfold"),	proj_lsqcm,
 	     ?__(522,"Project selected faces from normal and unfold the rest of chart")}
 	   ] ++ option_menu(),
-    wings_menu:popup_menu(X,Y, {auv,face}, Menu);
+    Win = wings_wm:this_win(),
+    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), {auv,face}, Menu);
 command_menu(edge, X, Y) ->
     Scale = scale_directions(true),
     Move = move_directions(true),
@@ -440,7 +442,8 @@ command_menu(edge, X, Y) ->
 	    {?__(66,"Stitch"), stitch, ?__(67,"Stitch edges/charts")},
 	    {?__(68,"Cut"), cut_edges, ?__(69,"Cut selected edges")}
 	   ] ++ option_menu(),
-    wings_menu:popup_menu(X,Y, {auv,edge}, Menu);
+    Win = wings_wm:this_win(),
+    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), {auv,edge}, Menu);
 command_menu(vertex, X, Y) ->
     Scale = scale_directions(true),
     Move = move_directions(true),
@@ -467,10 +470,12 @@ command_menu(vertex, X, Y) ->
 	    {?__(91,"SphereMap"),sphere,?__(92,"Create a spherical mapping with "
 	     "selected vertices being North/South pole")}
 	   ] ++ option_menu(),
-    wings_menu:popup_menu(X,Y, {auv,vertex}, Menu);
+    Win = wings_wm:this_win(),
+    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), {auv,vertex}, Menu);
 command_menu(_, X, Y) ->
     [_|Menu] = option_menu(),
-    wings_menu:popup_menu(X,Y, {auv,option}, Menu).
+    Win = wings_wm:this_win(),
+    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), {auv,option}, Menu).
 
 stretch_directions() ->
     [{?__(1,"Max Uniform"), max_uniform, ?__(2,"Maximize either horizontally or vertically")},

--- a/plugins_src/commands/wpc_sculpt.erl
+++ b/plugins_src/commands/wpc_sculpt.erl
@@ -923,10 +923,10 @@ set_values([]) -> ok.
 %%% Sculpt Menu
 %%%
 
-sculpt_menu(X0, Y0, Sc) ->
-    Pos = wings_wm:local2screen({X0, Y0}),
+sculpt_menu(Parent, Pos, Sc) ->
+%%    Pos = wings_wm:local2screen({X0, Y0}),
     Menu = sculpt_menu(Sc),
-    wings_menu:popup_menu(wings_wm:this_win(), Pos, sculpt, Menu).
+    wings_menu:popup_menu(Parent, Pos, sculpt, Menu).
 
 sculpt_menu(#sculpt{mag=Mag,mag_type=MagType,mode=Mode}) ->
     [{mode(pull)++"/"++mode(push),pull,?__(4,"Activate the Pull/Push sculpt tool"),crossmark(Mode, pull)},

--- a/src/wings.erl
+++ b/src/wings.erl
@@ -401,7 +401,7 @@ handle_event_2(#mousebutton{}=Ev, St) ->
 	    TweakBits = wings_msg:free_rmb_modifier(),
 	    case Mod band TweakBits =/= 0 of
 		true ->
-		    wings_tweak:menu(Xglobal, Yglobal);
+		    wings_tweak:menu(wings_wm:this_win(),wx_misc:getMousePosition());
 		false ->
 		    handle_popup_event(Ev, Xglobal, Yglobal, St)
 	    end
@@ -920,8 +920,7 @@ command_1({tools, put_on_ground}, St) ->
 command_1({tools, unitize}, St) ->
     {save_state,wings_align:unitize(St)};
 command_1({tools, tweak_menu}, _St) ->
-    {_,X,Y} = wings_wm:local_mouse_state(),
-    wings_tweak:menu(X, Y);
+    wings_tweak:menu(wings_wm:this_win(),wx_misc:getMousePosition());
 
 %% Develop menu.
 command_1({develop,Cmd}, St) ->
@@ -943,14 +942,16 @@ command_1({hotkey, Cmd}, St) ->
 popup_menu(X, Y, #st{sel=[]}) ->
     wings_shapes:menu(wings_wm:this_win(), wings_wm:local2screen({X,Y}));
 popup_menu(X, Y, #st{selmode=Mode}=St) ->
+    Win = wings_wm:this_win(),
+    Pos = wings_wm:local2screen({X,Y}),
     case wings_light:is_any_light_selected(St) of
-    true -> wings_light:menu(X, Y, St);
+    true -> wings_light:menu(Win, Pos, St);
     false ->
         case Mode of
-        vertex -> wings_vertex_cmd:menu(X, Y, St);
-        edge -> wings_edge_cmd:menu(X, Y, St);
-        face -> wings_face_cmd:menu(X, Y, St);
-        body -> wings_body:menu(X, Y, St)
+        vertex -> wings_vertex_cmd:menu(Win, Pos, St);
+        edge -> wings_edge_cmd:menu(Win, Pos, St);
+        face -> wings_face_cmd:menu(Win, Pos, St);
+        body -> wings_body:menu(Win, Pos, St)
         end
     end.
 

--- a/src/wings_body.erl
+++ b/src/wings_body.erl
@@ -20,7 +20,7 @@
 -import(lists, [foldl/3,mapfoldl/3,reverse/1,sort/1,seq/2]).
 -define(STR_LIGHT(A,B,Str), wings_lang:str({wings_light,A,B},Str)).
 
-menu(X, Y, St) ->
+menu(Parent, Pos, St) ->
     Dir = wings_menu_util:directions(St),
     Dup = flip_str(),
     FlipStrL = ?__(34,"Flip the object along ~s axis"),
@@ -99,7 +99,7 @@ menu(X, Y, St) ->
 	       {?__(49,"Remove All Attributes"),remove_all_attributes,
 		?__(50,"Remove all vertex colors and UV coordinates")}]}}|
 	    mode_dependent(St)],
-    wings_menu:popup_menu(X, Y, body, Menu).
+    wings_menu:popup_menu(Parent, Pos, body, Menu).
 
 rename_fun() ->
     fun

--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -25,7 +25,7 @@
 -import(e3d_vec, [add/2,sub/2,neg/1,norm/1,len/1,
 		  average/2, dot/2,cross/2]).
 
-menu(X, Y, St) ->
+menu(Parent, Pos, St) ->
     Dir = wings_menu_util:directions(St),
     Menu = [{?__(2,"Move"),{move,Dir},[],[magnet]},
 	    wings_menu_util:rotate(St),
@@ -64,7 +64,7 @@ menu(X, Y, St) ->
 	    separator,
 	    {?__(19,"Vertex Color"),vertex_color,
 	     ?__(20,"Apply vertex colors to selected edges")}],
-    wings_menu:popup_menu(X, Y, edge, Menu).
+    wings_menu:popup_menu(Parent, Pos, edge, Menu).
 
 connect() ->
     fun

--- a/src/wings_face_cmd.erl
+++ b/src/wings_face_cmd.erl
@@ -26,7 +26,7 @@
 -include("wings.hrl").
 -import(lists, [foldl/3,reverse/1,sort/1,keyfind/3,member/2]).
 
-menu(X, Y, St) ->
+menu(Parent, Pos, St) ->
     Dir = wings_menu_util:directions(St),
     Menu = [{?__(2,"Move"),{move,Dir},[],[magnet]},
 	    wings_menu_util:rotate(St),
@@ -77,7 +77,7 @@ menu(X, Y, St) ->
 	    separator] ++ wings_material:material_menu(St) ++
 	[{?__(30,"Vertex Color"),vertex_color,
 	  ?__(31,"Apply vertex colors to selected faces")}],
-    wings_menu:popup_menu(X, Y, face, Menu).
+    wings_menu:popup_menu(Parent, Pos, face, Menu).
 
 dissolve_fun() ->
     fun

--- a/src/wings_hotkey.erl
+++ b/src/wings_hotkey.erl
@@ -134,8 +134,8 @@ event_handler(Ev0= #mousebutton{}, #cs{info=Str, st=St, sc=Sc}) ->
             TweakBits = wings_msg:free_rmb_modifier(),
             case Mod band TweakBits =/= 0 of
 		true ->  case Sc of
-			     none -> wings_tweak:menu(Xglobal, Yglobal);
-			     _ -> wpc_sculpt:sculpt_menu(Xglobal, Yglobal, Sc)
+			     none -> wings_tweak:menu(wings_wm:this_win(),{Xglobal, Yglobal});
+			     _ -> wpc_sculpt:sculpt_menu(wings_wm:this_win(),{Xglobal, Yglobal}, Sc)
 			 end;
 		false -> wings:popup_menu(Xglobal, Yglobal, St)
             end

--- a/src/wings_light.erl
+++ b/src/wings_light.erl
@@ -1171,7 +1171,7 @@ light_types() ->
      {?__(9,"Area"),area,
       ?__(10,"Create an area that radiates light")}].
 
-menu(X, Y, St) ->
+menu(Parent, Pos, St) ->
     SpotOnly = {iff,[spot]},
     NotAmb = {iff,[spot,infinite,point,area]},
     One = one_light,
@@ -1199,7 +1199,7 @@ menu(X, Y, St) ->
 	     {One,{?__(16,"Edit Properties..."),edit,
 		   ?__(17,"Edit light properties")}}|body_menu(Dir, St)],
     Menu = filter_menu(Menu0, St),
-    wings_menu:popup_menu(X, Y, light, Menu).
+    wings_menu:popup_menu(Parent, Pos, light, Menu).
 
 body_menu(Dir, #st{selmode=body}) ->
     [separator,

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -67,10 +67,6 @@ is_popup_event(#wx{event=#wxCommand{type=command_right_click}}) ->
 is_popup_event(_Event) ->
     no.
 
-popup_menu(X, Y, Name, Menu) %% Should be removed, the next should be used !!
-  when is_number(X), is_number(Y) ->
-    Win = wings_wm:this_win(),
-    wx_popup_menu_init(Win, wxWindow:clientToScreen(Win, X, Y), [Name], Menu);
 popup_menu(Parent, {_,_} = GlobalPos, Name, Menu) ->
     wx_popup_menu_init(Parent, GlobalPos, [Name], Menu).
 

--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -1712,9 +1712,9 @@ show_cursor_1(X0,Y0) ->
 %%% Main Tweak Menu
 %%%
 
-menu(X, Y) ->
+menu(Parent, Pos) ->
     Menu = menu(),
-    wings_menu:popup_menu(X, Y, tweak, Menu).
+    wings_menu:popup_menu(Parent, Pos, tweak, Menu).
 
 menu() ->
     ToggleHelp = ?__(1,"Tweak is a collection of tools for quickly adjusting a mesh."),

--- a/src/wings_vec.erl
+++ b/src/wings_vec.erl
@@ -372,7 +372,8 @@ exit_menu(X, Y, Mod, #ss{f=Exit,vec=Vec}=Ss, St) ->
 	error ->
 	    Menu = [{wings_s:cancel(),abort,
 		     ?__(2,"Cancel current command")}],
-	    wings_menu:popup_menu(X, Y, secondary_selection, Menu);
+	    Win = wings_wm:this_win(),
+	    wings_menu:popup_menu(Win, wxWindow:clientToScreen(Win, X, Y), secondary_selection, Menu);
 	keep ->
 	    keep;
 	{Do,Done} ->

--- a/src/wings_vertex_cmd.erl
+++ b/src/wings_vertex_cmd.erl
@@ -20,7 +20,7 @@
 -include("wings.hrl").
 -import(lists, [member/2,foldl/3,mapfoldl/3,sort/1]).
 
-menu(X, Y, St) ->
+menu(Parent, Pos, St) ->
     Dir = wings_menu_util:directions(St),
     Menu = [{?STR(menu,2,"Move"),{move,Dir},[],[magnet]},
 	    wings_menu_util:rotate(St),
@@ -46,7 +46,7 @@ menu(X, Y, St) ->
 	    separator,
 	    {?STR(menu,15,"Vertex Color"),vertex_color,
 	     ?STR(menu,16,"Apply vertex colors to selected vertices")}],
-    wings_menu:popup_menu(X, Y, vertex, Menu).
+    wings_menu:popup_menu(Parent, Pos, vertex, Menu).
 
 connect_menu() ->
     fun


### PR DESCRIPTION
It was adjusted the calls to the old header of wings_menu:popup_menu/4 
function to be in accordance with a note in wings_menu source code.

This update requires the one in 'mv/v2.2.5.dev-context-menu-fix' in order
to properly place the menu window close to the mouse in the current
display in use - reason why it was built using that branch.