### PR TITLE
Fix the mouse release error message

### DIFF
--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -195,7 +195,7 @@ wx_popup_menu(Parent,Pos,Names,Menus0,Magnet,Owner) ->
 			   wx:set_env(Env),
 			   {Frame, Panel, MEs, Cols} = wx:batch(CreateMenu),
 			   popup_events(Frame, Panel, MEs, Cols, Magnet, undefined, Names, Owner),
-                           wxWindow:releaseMouse(Panel),
+			   wxWindow:hasCapture(Panel) andalso wxWindow:releaseMouse(Panel),
                            wxWindow:hide(Frame),
                            wxFrame:destroy(Frame)
 		       catch _:Reason ->


### PR DESCRIPTION
This fix the mouse release error message we get on Erlang console, although
the error isn't displayed in the compiled version of Wings3D. I noticed it
only when the context menus were opened and a new App get focused.

Maybe it would be maybe generated by not processing the window event
wxMouseCaptureLostEvent.
Ref.: https://docs.wxwidgets.org/trunk/classwx_mouse_capture_lost_event.html

These are the messages now skipped:
wx: error
message: wxWidgets Assert failure: ..\..\src\common\wincmn.cpp(3300):
"Assert failure" in wxWindowBase::ReleaseMouse() : Releasing mouse in
00000000100415F0(wxWindow) but it is not captured

wx: error
message: wxWidgets Assert failure: ..\..\src\common\wincmn.cpp(3319):
"!wxMouseCapture::stack.empty()" in wxWindowBase::ReleaseMouse() : Releasing
mouse capture but capture stack empty?