### PR TITLE
Fixed bad behaviour of screenshot option

### DIFF
--- a/src/wings_image.erl
+++ b/src/wings_image.erl
@@ -14,7 +14,7 @@
 -module(wings_image).
 -export([from_file/1,new/2,new_temp/2,new_hidden/2, create/1,
 	 rename/2,info/1,images/0,
-	 screenshot/2,screenshot/1,viewport_screenshot/1,
+	 screenshot/2,viewport_screenshot/1,
 	 txid/1,bumpid/1, combid/1,
 	 is_normalmap/1,
 	 next_id/0,delete_older/1,delete_from/1,delete/1,
@@ -160,53 +160,45 @@ req(Req, Notify) ->
     Reply.
 
 screenshot(Ask, _) when is_atom(Ask) ->
-    ViewPortOnly = wings_pref:get_value(screenshot_viewport_only, false),
     SaveView = wings_pref:get_value(screenshot_save_current_view, false),
-    Qs = [{?__(2,"Capture viewport only"),ViewPortOnly},
-          {?__(3,"Add current view to Saved Views"),SaveView},
+    Qs = [{?__(3,"Add current view to Saved Views"),SaveView},
           {hframe,[{label,?__(4,"Name")},
 		   {text,?__(1,"Screenshot"),[]}]}],
     wings_dialog:dialog(Ask, ?__(1,"Screenshot"), [{vframe,Qs}],
 			fun(Res) -> {tools,{screenshot,Res}} end);
-screenshot([ViewPortOnly,SaveView,Name], St) ->
-    wings_pref:set_value(screenshot_viewport_only, ViewPortOnly),
+screenshot([SaveView,Name], St) ->
     wings_pref:set_value(screenshot_save_current_view, SaveView),
-    wings_wm:send_after_redraw(geom,{action,{tools,{screenshot,[ViewPortOnly,Name]}}}),
+    wings_wm:send_after_redraw(geom,{action,{tools,{screenshot,[Name]}}}),
     case SaveView of
       true -> wings_view:command({views,{save,[Name]}},St);
       false -> St
     end;
-screenshot([ViewPortOnly,Name], St) ->
-    case ViewPortOnly of
-      true -> viewport_screenshot(Name);
-      false -> screenshot(Name)
-    end,
+screenshot(Name, St) ->
+    viewport_screenshot(Name),
     St.
-
-screenshot(Name) ->
-    {W,H} = wings_wm:top_size(),
-    gl:pixelStorei(?GL_PACK_ALIGNMENT, 1),
-    gl:readBuffer(?GL_FRONT),
-    Mem = wings_io:get_buffer(W*H*3, ?GL_UNSIGNED_BYTE),
-    gl:readPixels(0, 0, W, H, ?GL_RGB, ?GL_UNSIGNED_BYTE, Mem),
-    ImageBin = wings_io:get_bin(Mem),
-    Image = #e3d_image{image=ImageBin,width=W,height=H},
-    Id = new_temp(Name, Image),
-    window(Id).
 
 viewport_screenshot(Name) ->
 %% screenshot of just the viewport scene
-    {X,Y,W0,H0} = wings_wm:viewport(),
+    GeomWin =
+        case wings_wm:actual_focus_window() of
+            undefined -> geom;
+            Win -> Win
+        end,
+    {W0,H0} = wings_wm:win_size(GeomWin),
     Scale = wings_wm:win_scale(),
-    W = round(W0*Scale), H = round(H0*Scale),
-    gl:pixelStorei(?GL_PACK_ALIGNMENT, 1),
-    gl:readBuffer(?GL_FRONT),
-    Mem = wings_io:get_buffer(W*H*3, ?GL_UNSIGNED_BYTE),
-    gl:readPixels(X, Y, W, H, ?GL_RGB, ?GL_UNSIGNED_BYTE, Mem),
-    ImageBin = wings_io:get_bin(Mem),
-    Image = #e3d_image{image=ImageBin,width=W,height=H},
-    Id = new_temp(Name, Image),
-    window(Id).
+    case wings_wm:redraw_geom(GeomWin) of
+        ignore -> ok;
+        _ ->
+            W = round(W0*Scale), H = round(H0*Scale),
+            gl:pixelStorei(?GL_PACK_ALIGNMENT, 1),
+            gl:readBuffer(?GL_FRONT),
+            Mem = wings_io:get_buffer(W*H*3, ?GL_UNSIGNED_BYTE),
+            gl:readPixels(0, 0, W, H, ?GL_RGB, ?GL_UNSIGNED_BYTE, Mem),
+            ImageBin = wings_io:get_bin(Mem),
+            Image = #e3d_image{image=ImageBin,width=W,height=H},
+            Id = new_temp(Name, Image),
+            window(Id)
+    end.
 
 %%%
 %%% Server implementation.

--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -47,7 +47,7 @@
 -export([get_props/1,get_prop/1,get_prop/2,lookup_prop/1,lookup_prop/2,
 	 set_win_props/2, set_prop/2,set_prop/3,erase_prop/1,erase_prop/2,
 	 is_prop_defined/2,
-	 get_dd/0, get_dd/1, set_dd/2
+	 get_dd/0, get_dd/1, set_dd/2, redraw_geom/1
 	]).
 
 -export([get_value/1, set_value/2, delete_value/1]).
@@ -505,7 +505,7 @@ win_scale() ->
 
 viewport(Name) ->
     #win{x=X,y=Y0,w=W,h=H} = get_window_data(Name),
-    {_,TopH} = get(wm_top_size),
+    {_,TopH} = wings_wm:top_size(),
     Y = TopH-(Y0+H),
     {X,Y,W,H}.
 
@@ -927,6 +927,15 @@ redraw_win({Name, #win{w=W,h=H,obj=Obj,scale=Scale}}) ->
     case do_dispatch(Name, redraw) =/= deleted andalso DoSwap of
         false -> ok;
         true  -> wxGLCanvas:swapBuffers(Obj)
+    end.
+
+redraw_geom(Name) ->
+    Windows = keysort(2, gb_trees:to_list(get(wm_windows))),
+    case lists:keyfind(Name,1,Windows) of
+        {Name, _} = Win ->
+            redraw_win(Win);
+        _ ->
+            ignore
     end.
 
 use_opengl(undefined) -> false;


### PR DESCRIPTION
The screenshot command was always getting the image size from the main geometry
window (by considering a layout with multiple ones)- wings_wm:this() was always
referencing 'geom' window. But the copied buffer was the last one drawn (maybe).
To ensure we were copying the proper one it was added a new function to
wings_wm to allow us require a specific geometry window to be drawn and then
we can access the correct OpenGL buffer.

When a detached geometry window is active it loses the focus when we use the
main menu. So, in this case the main geometry window will be used for capture.

It was also removed the option to capture the entire window since it was not
working well since we started to use the wx library (requested by Dan).

NOTE: Fixed the screenshot command which was only capturing the main
geometry window and cutting it on top.