### PR TITLE
Fixed the missing right message in the information line

### DIFF
--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -454,7 +454,9 @@ grab_focus(Name) ->
 	    %%{_, [_,Where|_]} = erlang:process_info(self(), current_stacktrace),
 	    %%io:format("Grab focus: ~p~n   ~p~n",[Name, Where]),
 	    case get(wm_focus_grab) of
-		undefined -> put(wm_focus_grab, [Name]);
+		undefined ->
+		    update_focus(Name),
+		    put(wm_focus_grab, [Name]);
 		Stack -> put(wm_focus_grab, [Name|Stack])
 	    end;
 	false -> ok


### PR DESCRIPTION
**I'm not sure this fix was mad in the appropriated way**, but it was needed in order to ensure the
wm_focus data used in wings_wm:message_event(redraw) get the correct focused
window instead of 'undefined' and this way the status bar can be updated.

NOTE: The right message used to show extra information to the user actions
was missing with the previous message kept static. Thanks to Sevendy3