### PR TITLE
Fixed the Hexagon texture shader which was not working

### DIFF
--- a/plugins_src/autouv/shaders/hexagon.fs
+++ b/plugins_src/autouv/shaders/hexagon.fs
@@ -55,8 +55,8 @@ vec4 hexagon1(in float d)
 {
   float k = d;
   float ik = (1.0-k);
-  kcolor = colorHex;
-  kbkcolor = colorThick;
+  kcolor = vec4(vec3(colorHex.rgb)*k,colorHex.a*k);
+  kbkcolor = vec4(vec3(colorThick.rgb)*ik,colorThick.a*ik);
   return vec4(kbkcolor+kcolor);
 }
 
@@ -64,8 +64,8 @@ vec4 hexagon2(in float d)
 {
   float k = min(d,1.0);
   float ik = (1.0-k);
-  kcolor = colorHex;
-  kbkcolor = colorThick;
+  kcolor = colorHex*k;
+  kbkcolor = colorThick*ik;
   if (k >= 1.0) {
     return kcolor;
   } else if (ik >= 0.90) {


### PR DESCRIPTION
It was noticed that option for "Pineapple Fruits style" was not working for
long time. There were some missing coeficient since a review made in the
opacity property.

NOTE: Hexagon in texture shader was broken. Thanks to tkbd