### PR TITLE
WRML plugin was exporting wrong material settings

### DIFF
--- a/plugins_src/import_export/wpc_wrl.erl
+++ b/plugins_src/import_export/wpc_wrl.erl
@@ -194,16 +194,23 @@ def_material(F, Name, Mat0, Dir) ->
     Mat = lookup(opengl, Mat0),
     io:format(F, "      appearance Appearance {\n",[]),
     io:format(F, "        material DEF ~s Material {\n",[clean_id(Name)]),
-    {Ar, Ag, Ab, O} = lookup(ambient, Mat),
+    {Ar, Ag, Ab, O0} = lookup(ambient, Mat),
     {Dr, Dg, Db, _} = lookup(diffuse, Mat),
     io:format(F, "          diffuseColor ~p ~p ~p\n",[Dr, Dg, Db]),
     {Er, Eg, Eb, _} = lookup(emission, Mat),
     io:format(F, "          emissiveColor ~p ~p ~p\n", [Er, Eg, Eb]),
     {Sr, Sg, Sb, _} = lookup(specular, Mat),
     io:format(F, "          specularColor ~p ~p ~p\n",[Sr, Sg, Sb]),
-    Amb = (Ar+Ag+Ab)/3,
+    case (Ar+Ag+Ab)/3 of
+        0.0 ->
+            Amb = 1.0, %% wrml needs a non zero value for ambient intensity
+            O = 0.0;
+        Amb0 ->
+            Amb = Amb0,
+            O = 1.0-O0
+    end,
     io:format(F, "          ambientIntensity ~p\n",[Amb]),
-    io:format(F, "          transparency ~p\n",[1.0-O]),
+    io:format(F, "          transparency ~p\n",[O]),
     S = lookup(shininess, Mat),
     io:format(F, "          shininess ~p\n",[S]),
     io:put_chars(F, "        }\n"),


### PR DESCRIPTION
Fixed wrong material setting after the material changes intruduced due new
PBR render.

After the material changes the ambient color property is set to
{0.0,0.0,0.0,1.0} and was causing the exported values ambientIntensity and
transparency to be inverted causing object to not be shown;

To minimize any impact of any older project being opened in a previous version
of Wings3D it was only checked it the ambient valuer is zero. In this case we
assume we have to fixe these properties.

From: http://gun.teipir.gr/VRML-amgem/spec/part1/nodesRef.html#Material
- The ambientIntensity field specifies how much ambient light from light sources
  this surface should reflect. Ambient light is omni-directional and depends
  only on the number of light sources, not their positions with respect to the
  surface. Ambient color is calculated as ambientIntensity * diffuseColor.
- Transparency is how "clear" the object is, with 1.0 being completely
  transparent, and 0.0 completely opaque.

NOTE: WRML plugin was exporting inverted values for ambientIntensity and
Trasparency. Thanks to greg.