### PR TITLE
The changes to makefile allow us to use the .bashrc fake the WSL use.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -24,7 +24,14 @@ endif
 ifdef MSYSTEM
  ifeq ($(MSYSTEM),$(filter $(MSYSTEM),MINGW32 MINGW64))
   USEMINGWGCC := true
-  DEF_CC = gcc
+  ifeq (x$(CC),x)
+    DEF_CC = gcc
+  else
+    DEF_CC = $(CC)
+    ifeq ($(WSLcross), true)
+      UseMCL = true
+    endif
+  endif
  endif
 else
  ifeq ($(WSLcross), true)
@@ -55,8 +62,8 @@ ifeq ($(UseMCL),true)
  OBJ = obj
  SO_EXT = dll
  LIBS = -LD
- CFLAGS += -nologo -Zi -Ox /FS /MP -D__WIN32__
- CXXFLAGS += $(CFLAGS) /EHsc
+ CFLAGS += -nologo -Zi -Ox -FS -MP -D__WIN32__
+ CXXFLAGS += $(CFLAGS) -EHsc
 else
  OUT = -o
  OUT_OBJ = -o

--- a/win32/SetupWSLcross.bat
+++ b/win32/SetupWSLcross.bat
@@ -60,12 +60,13 @@ wsl.exe echo export 'INCLUDE LIB LIBPATH VCToolsRedistDir WSLENV PATH WSLcross';
 wsl.exe echo "# Eval this file eval \`cmd.exe /c SetupWSLcross.bat\`"
 
 rem done
-exit
+goto end
 
 :badarg
 echo "Bad TARGET or not specified: %~1 expected x86 or x64"
-exit
+goto end
 
 :no_vcvars
 echo "Error: SetupWSLcross.bat: Could not find vcvarsall.bat"
-exit
+
+:end


### PR DESCRIPTION
I made these changes to makefile to allow us to use the _.bashrc_ fake the _WSL_ use.

In the _.bashrc_ we then can set the variable like this:
```
 :
MCL="$(which cl.exe | grep -i -Po 'cl.exe')"
if test "x$MCL" = "x"; then
  echo "Linux Compiler to be used."
  export CC=gcc
  export OPENCL_DIR=/mingw64
  export PATH="$ERL_PATH/bin":$PATH  #v2.2.6
else
  echo "Miscrosoft Compiler to be used."
  export WSLcross=true
  export CC=cl.exe
  export OPENCL_DIR="'/C/Program Files (x86)/Microsoft Visual Studio/2019/Community/
                      VC/Tools/MSVC/14.26.28801'"
  export PATH="/c/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/
               MSVC/14.26.28801/bin/Hostx64/$BV":$PATH
fi
 :
```

and then, in the _makefile_ - with minimal changes - we check if the user has already set _$CC_ before fake the use of _MLC_ for entire script (_UseMCL=true_).

The change to the ??_FLAGS_ - replacing the slash(**/**) by the dash(**-**) - avoid the compiler
to fail in MSys environment and it's not a problem in _WSL_.