### PR TITLE
Changed the renaming dialogs to show a wider input name

### DIFF
--- a/plugins_src/commands/wpc_sel_win.erl
+++ b/plugins_src/commands/wpc_sel_win.erl
@@ -133,7 +133,7 @@ rename({_,OldName}=Id) ->
               {label,OldName}]},
             {hframe,[
               {label,?__(3,"New name")++": "},
-              {text,"",[]}]}
+              {text,OldName,[{width,22}]}]}
            ]}],
     wings_dialog:dialog(?__(1,"Rename"), Qs,
     fun([[]]) -> ignore;

--- a/src/wings_body.erl
+++ b/src/wings_body.erl
@@ -784,7 +784,7 @@ rename_2([], [], St) -> St.
 
 rename_qs(Objs) ->
     OldNames = [{label,Name} || #{name:=Name} <- Objs],
-    TextFields = [{text,Name,[]} || #{name:=Name} <- Objs],
+    TextFields = [{text,Name,[{width,22}]} || #{name:=Name} <- Objs],
     [{hframe,
       [{vframe,OldNames},
        {vframe,TextFields}]}].

--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -1488,7 +1488,7 @@ build_textctrl(Ask, Def, Flags, {MaxSize, Validator}, Parent, Sizer) ->
 	    wxTextCtrl:setMaxSize(Ctrl, {MaxSize*CharWidth, -1});
 	Width when is_integer(Width) ->
 	    wxTextCtrl:setMaxSize(Ctrl, {CharWidth*(Width+1), -1}),
-	    wxTextCtrl:setMaxSize(Ctrl, {CharWidth*Width, -1});
+	    wxTextCtrl:setMinSize(Ctrl, {CharWidth*Width, -1});
 	undefined -> %% Let the sizer handle the max and min sizes
 	    ok
     end,

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -159,7 +159,7 @@ rename_2([], St) -> St.
 
 rename_qs(Ms) ->
     OldNames = [{label,M} || M <- Ms],
-    TextFields = [{text,M,[{key,list_to_atom(M)}]} || M <- Ms],
+    TextFields = [{text,M,[{key,list_to_atom(M)},{width,22}]} || M <- Ms],
     [{hframe,
       [{vframe,OldNames},
        {vframe,TextFields}]}].

--- a/src/wings_outliner.erl
+++ b/src/wings_outliner.erl
@@ -181,7 +181,7 @@ copy_of(Name) -> "Copy of "++Name.
 rename_image(Id) ->
     #e3d_image{name=Name0} = wings_image:info(Id),
     wings_dialog:ask(?__(1,"Rename Image"),
-		     [{Name0,Name0,[]}],
+		     [{Name0,Name0,[{width,22}]}],
 		     fun([Name]) when Name =/= Name0 ->
 			     wings_image:rename(Id, Name),
 			     wings_wm:send(geom, need_save),

--- a/src/wings_sel_cmd.erl
+++ b/src/wings_sel_cmd.erl
@@ -592,7 +592,7 @@ save_group(Key, Sel, #st{ssels=Ssels0}=St) ->
 
 new_group(_) ->
     wings_dialog:ask(?__(1,"Create New Group"),
-		     [{?__(2,"Group Name"), ""}],
+		     [{?__(2,"Group Name"), "",[{width,22}]}],
 		     fun([String]) -> {select,{new_group_name,String}} end).
 
 new_group_name(Name, #st{ssels=Ssels0,selmode=Mode,sel=Sel}=St) ->

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -1096,7 +1096,7 @@ views_save_dialog(Ask, Options) ->
 			fun(Opts) -> {view,{views,{save,Opts}}} end).
 
 views_rename_qs([Legend]) ->
-    [{hframe,[{label,?__(1,"Name")},{text,Legend}]}].
+    [{hframe,[{label,?__(1,"Name")},{text,Legend,[{width,22}]}]}].
 
 views_jump(J, St, CurrentView, Views) ->
     S = tuple_size(Views),


### PR DESCRIPTION
It was also needed to fix the wings_dialogs.erl in order to fix the text
control which was not taking correctly in account the 'width' flag.

NOTE: Input dialogs to name/rename elements now is a little wider. Thanks tkbd
for the suggestion.