### PR TITLE
Fixed select similar command for an empty scene

### DIFF
--- a/src/wings_sel_cmd.erl
+++ b/src/wings_sel_cmd.erl
@@ -693,7 +693,7 @@ similar(#st{selmode=body}=St) ->
 			   member(Template, Templates)
 		   end, body, St).
 
-do_similar(MakeTemplate, #st{selmode=Mode}=St) ->
+do_similar(MakeTemplate, #st{selmode=Mode,sel=Sel0}=St) when Sel0 =/= [] ->
     MF = fun(Sel, We) ->
 		 Ts = gb_sets:fold(
 			fun(I, A) ->
@@ -708,7 +708,8 @@ do_similar(MakeTemplate, #st{selmode=Mode}=St) ->
       fun(Item, We) ->
 	      Template = MakeTemplate(Item, We),
 	      match_templates(Template, Templates)
-      end, Mode, St).
+      end, Mode, St);
+do_similar(_, St) -> St.
 
 consolidate_templates([H|T]) ->
     consolidate_templates_1(H, T).


### PR DESCRIPTION
NOTE: Run the Select->Similar command in an empty was causing Wings3D to
display the 'Delete Hotkey' dialog.