### PR TITLE
Added a dialog to STL exporter

### DIFF
--- a/plugins_src/import_export/wpc_stl.erl
+++ b/plugins_src/import_export/wpc_stl.erl
@@ -52,10 +52,7 @@ do_export(Ask, Op, _Exporter, _St) when is_atom(Ask) ->
                fun(Res) ->
                    {file,{Op,{stl,Res}}}
                end);
-do_export(Attr0, _Op, Exporter, _St) when is_list(Attr0) ->
-    %% we store only the selected row id. The table control
-    %% will return the entire list plus the selection.
-    {value,{slicer,_},Attr} = lists:keytake(slicer,1,Attr0),
+do_export(Attr, _Op, Exporter, _St) when is_list(Attr) ->
     set_pref(Attr),
     SubDivs = proplists:get_value(subdivisions, Attr, 0),
     Ps = [{subdivisions,SubDivs}|props()],
@@ -70,54 +67,14 @@ set_pref(KeyVals) ->
 
 dialog_export() ->
     Hook = fun(Key, Value, Fields) ->
-            {Sel,Lists} = Slicer = wings_dialog:get_value(slicer,Fields),
             case Key of
-                slicer ->
-                    wings_dialog:set_value(slicer_id,Sel,Fields),
-                    case Sel of
-                        [0] ->
-                            ObjScale = 1.0,
-                            ConvScale = 1.0,
-                            wings_dialog:set_value(wu_equals,stl,Fields),
-                            wings_dialog:set_value(obj_scale,ObjScale,Fields),
-                            wings_dialog:set_value(conv_scale,ConvScale,Fields),
-                            wings_dialog:enable(pnl_slicer,false,Fields),
-                            wings_dialog:enable(obj_scale,false,Fields);
-                        _ ->
-                            ObjScale = wings_dialog:get_value(obj_scale,Fields),
-                            ConvScale = comput_scale(wings_dialog:get_value(wu_equals,Fields),Slicer)
-                    end,
-                    wings_dialog:set_value(conv_scale,ConvScale,Fields),
-                    wings_dialog:set_value(export_scale,ObjScale*ConvScale,Fields);
                 wu_equals ->
-                    %% workaround to set the previous selected item on table since
-                    %% the table control doesn't allow us to set its initial value
-                    SlicerId = wings_dialog:get_value(slicer_id,Fields),
                     ObjScale = wings_dialog:get_value(obj_scale,Fields),
-                    case Value of
-                        stl ->
-                            %% setting table default selection to Wings3D scale
-                            ConvScale = 1.0,
-                            SlicerCtrl = wings_dialog:get_widget(slicer,Fields),
-                            wxListCtrl:setItemState(SlicerCtrl,0,?wxLIST_STATE_SELECTED,?wxLIST_STATE_SELECTED);
-                        _ ->
-                            %% computing the conversion scale based on slicer preset
-                            case Sel of
-                                [] when SlicerId=/=[], Value=/=stl ->
-                                    [Id] = SlicerId,
-                                    SlicerCtrl = wings_dialog:get_widget(slicer,Fields),
-                                    wxListCtrl:setItemState(SlicerCtrl,Id,?wxLIST_STATE_SELECTED,?wxLIST_STATE_SELECTED),
-                                    ConvScale = comput_scale(Value, {SlicerId,Lists});
-                                [_] ->
-                                    ConvScale = comput_scale(Value,Slicer)
-                            end
-                    end,
+                    ConvScale = conv_scale(Value),
                     wings_dialog:set_value(conv_scale,ConvScale,Fields),
                     wings_dialog:set_value(export_scale,ObjScale*ConvScale,Fields),
-                    wings_dialog:enable(pnl_slicer,Value=/=stl,Fields),
                     wings_dialog:enable(conv_scale,false,Fields),
-                    wings_dialog:enable(obj_scale,Value=/=stl,Fields),
-                    wings_dialog:update(pnl_slicer,Fields);
+                    wings_dialog:enable(pnl_slicer,Value=/=stl,Fields);
                 obj_scale ->
                     ConvScale = wings_dialog:get_value(conv_scale,Fields),
                     wings_dialog:set_value(export_scale,Value*ConvScale,Fields)
@@ -135,33 +92,24 @@ dialog_export() ->
             }
         ]},
       {vframe, [
-        {vframe, [
-          {label, ?__(4,"Below you have some scale information to get 1WU = 1mm\n"
-                        "in accord with information we got from Wings3D's users.\n\n"
-                        "Select a row to compute the 'Export scale' value:")},
-          {table,[{"Slicer Software", "1WU", "Scale"},
-                  {{0,"default Wings3D settings"},{1.0,"1STL unit"},{1.0,"1.0"}},
-                  {{1,"Chitubox"},                {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{2,"Cura (Ultimaker)"},        {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{3,"ideaMaker (Raise3D)"},     {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{4,"Makerbot Print"},          {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{5,"Repetier Host"},           {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{6,"Slic3r"},                  {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{7,"Tinkerine™ Suite"},        {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{8,"Up Studio (Tiertime)"},    {25.4,"1inch"},   {0.0393700787401575,"0.0393701"}},
-                  {{9,"Z-Suite (Zortrax)"},       {1.0,"1mm"},      {1.0,"1.0"}},
-                  {{10,"3DWOX Desktop (Sindoh)"}, {1.0,"1mm"},      {1.0,"1.0"}}
-          ],[{key,slicer},{sel_style,single},{hook,Hook},
-             {max_rows,4},{col_widths,{20,7,8}}]},
-          {value,wpa:pref_get(?MODULE, slicer_id, []),[{key,slicer_id}]}
-        ],[{margin,false},{key,pnl_slicer}]},
+       {vframe, [
+        {hframe, [
+         {label, ?__(4,"NOTE: By testing the slicers tools below\n"
+                       "it was noticed they translate 1STL unit to 1mm.\n"
+                       "So, we can say that 1WU = 1STL (1mm).")++
+                       "\n\nSlicers: Chitubox, Cura, ideaMaker, Makerbot Print,\n"
+                       "Repetier Host, Slic3r, Tinkerine™ Suite,\n"
+                       "Z-Suite, 3DWOX Desktop."}
+        ]},
+        separator,
         {label_column, [
             {?__(7,"Conversion scale"),
              {text,1.0,[{key,conv_scale},{range,{0.0,infinity}}]}},
             {?__(8,"Object scale"),
              {text,wpa:pref_get(?MODULE,obj_scale,1.0),[{key,obj_scale},{range,{0.0,infinity}},{hook,Hook}]}}
         ]}
-      ],[{title," "++?__(9,"Slicer software references")++" "},{margin,false}]},
+       ],[{title," "++?__(9,"Slicer software information")++" "}]}
+      ],[{key,pnl_slicer},{margin,false}]},
       {label_column,
        [{?__(2,"Export scale"),
          {text,wpa:pref_get(?MODULE, export_scale, 1.0),
@@ -173,18 +121,11 @@ dialog_export() ->
      ]}
     ].
 
-comput_scale(WUeq, {Sel,List}) ->
-    case Sel of
-        [Idx] ->
-            Row = element(Idx+1,list_to_tuple(List)),
-            {Scale,_} = element(3,Row),
-            %% Scale is defined in millimeters, so we convert in accord with user selection
-            case WUeq of
-                mm -> Scale;
-                cm -> Scale*10.0;
-                inch -> Scale*25.4;
-                _ -> 1.0
-            end;
+conv_scale(WUeq) ->
+    %% Scale is defined in millimeters, so we convert in accord with user selection
+    case WUeq of
+        cm -> 10.0;
+        inch -> 25.4;
         _ -> 1.0
     end.
 

--- a/plugins_src/import_export/wpc_stl.erl
+++ b/plugins_src/import_export/wpc_stl.erl
@@ -76,14 +76,17 @@ dialog_export() ->
                     wings_dialog:set_value(slicer_id,Sel,Fields),
                     case Sel of
                         [0] ->
-                            wings_dialog:set_value(wu_equals,stl,Fields),
+                            ObjScale = 1.0,
                             ConvScale = 1.0,
+                            wings_dialog:set_value(wu_equals,stl,Fields),
+                            wings_dialog:set_value(obj_scale,ObjScale,Fields),
+                            wings_dialog:set_value(conv_scale,ConvScale,Fields),
                             wings_dialog:enable(pnl_slicer,false,Fields),
                             wings_dialog:enable(obj_scale,false,Fields);
                         _ ->
+                            ObjScale = wings_dialog:get_value(obj_scale,Fields),
                             ConvScale = comput_scale(wings_dialog:get_value(wu_equals,Fields),Slicer)
                     end,
-                    ObjScale = wings_dialog:get_value(obj_scale,Fields),
                     wings_dialog:set_value(conv_scale,ConvScale,Fields),
                     wings_dialog:set_value(export_scale,ObjScale*ConvScale,Fields);
                 wu_equals ->
@@ -162,7 +165,7 @@ dialog_export() ->
       {label_column,
        [{?__(2,"Export scale"),
          {text,wpa:pref_get(?MODULE, export_scale, 1.0),
-          [{key,export_scale}]}},
+          [{key,export_scale},{range,{0.0,infinity}}]}},
         {?__(3,"Sub-division Steps"),
          {text,wpa:pref_get(?MODULE, subdivisions, 0),
           [{key,subdivisions},{range,{0,4}}]}}


### PR DESCRIPTION
It was added a simplified export dialog including the option for scale
and subdivide the scene. It was also added a drop down list for unit
conversion (1WU to 1STL/1mm/1cm/1inch), the conversion scale and
the object scale.
The combination of the first two generates the value for the conversion
scale which multiplied by the object scale results in a update for the
'Export scale' text box.
There are some information about a list of some knowing slicer 
softwares we tested and checked that 1 STL unit is converted to 1mm.
That should help the users to understand its relationship with the 
Wings3D unit (1WU = 1STL unit)

![STL-exporter](https://user-images.githubusercontent.com/365243/89069298-44e2a980-d349-11ea-8500-86769928b01f.png)


NOTE: Added a dialog to STL exporter allowing users to set the scale.
Thanks to dawntreader, imagine and Mert HANCIOGLU(instagram) for provide
us information about the slicers measures and to oort for testing.