### PR TITLE
Fixed the help windows being hidden by geometry grabing focus

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -208,7 +208,7 @@ init() ->
 %% Display a text window (Info converted to html)
 info(Title, Info, Options) ->
     Parent = proplists:get_value(parent, Options, get_dialog_parent()),
-    Flags  = [{size, {500, 400}}, {style, ?wxCAPTION bor ?wxRESIZE_BORDER bor ?wxCLOSE_BOX}],
+    Flags  = [{size, {500, 400}}, {style, ?wxCAPTION bor ?wxRESIZE_BORDER bor ?wxCLOSE_BOX bor ?wxFRAME_FLOAT_ON_PARENT}],
     Frame  = wxFrame:new(Parent, ?wxID_ANY, Title, Flags),
     Panel  = wxHtmlWindow:new(Frame, []),
     Sizer  = wxBoxSizer:new(?wxVERTICAL),


### PR DESCRIPTION
It was reported that any of the windows opened from the Help option becomes
hidden by the main window as soon as the mouse lay over the geometry window.
This behaviour started in v2.2.5 after the inclusion of a call to
update_focus/1 in wings_wm:grab_focus/1 (https://github.com/dgud/wings/commit/234f62338a1c8afdd6fb976f1a37247b0099ee1f#diff-8a2f0ce40501e1138f9babada3f5e4a4R458)
In order to make it have the old behaviour (keep visible over the main window)
we need to add the stay on top flag to the wxFrame style.

NOTE: Fixed the help windows visibility which were getting hidden when moving
the mouse outside it. Thanks Grumbler.