### PR TITLE
Fixed crash caused by garbage left when dissolving faces

### DIFF
--- a/src/wings_dissolve.erl
+++ b/src/wings_dissolve.erl
@@ -51,14 +51,21 @@ complement(Fs, We) -> complement(gb_sets:to_list(Fs), We).
 dissolve_1(Faces, Complement, We0) ->
     We1 = optimistic_dissolve(Faces,Complement,We0#we{vc=undefined}),
     NewFaces = wings_we:new_items_as_ordset(face, We0, We1),
-    We2 = wings_face:delete_bad_faces(NewFaces, We1),
-    We = wings_we:rebuild(We2),
+    #we{holes=Holes0} = We2 = wings_face:delete_bad_faces(NewFaces, We1),
+    Holes = update_holes(Holes0,Faces),
+    We = wings_we:rebuild(We2#we{holes=Holes}),
     case wings_we:is_consistent(We) of
 	true ->
 	    We;
 	false ->
 	    wings_u:error_msg(?__(1,"Dissolving would cause an inconsistent object structure."))
     end.
+
+update_holes([], _) -> [];
+update_holes(Holes, Fs) when is_list(Fs) ->
+    Holes--Fs;
+update_holes(Holes, Fs) ->
+    update_holes(Holes, gb_sets:to_list(Fs)).
 
 optimistic_dissolve(Faces0, Compl, We0) ->
     %% Optimistically assume that we have a simple region without


### PR DESCRIPTION
It was noticed that by using commands like 'Select Similar Normals' the
faces marked as hole was also selected and by dissolving the selection
the #we{}.holes was not updated to remove these faces.

It was opted to keep the holes or hidden faces select since for some commands
it can be of interest move these faces too. This is noticeable with hidden
faces when becoming visible will be close to the ones moved previously.