### PR TITLE
Fixed collada importer error

### DIFF
--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -215,6 +215,7 @@ simplify_float_1("0"++F) -> simplify_float_1(F);
 simplify_float_1(F) -> F.
 
 
+string_to_float("NaN") -> 0.0;
 string_to_float(Str) ->
     try list_to_float(Str)
     catch _:_ -> make_float2(Str)


### PR DESCRIPTION
It was noticed collada may generate files with NaN for float numbers. As
checked, others 3D apps use to automatically to convert them to 0.0, so
it was changed the wings_util:string_to_float/1 in order to fix that.
This will prevent any other importer to break Wings3D in the future.

NOTE: Fixed the collada inporter error caused by NaN values. Thanks to tkbd