### PR TITLE
Fixed a build error when making libigl in msys2 environment.

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -55,8 +55,8 @@ ifeq ($(UseMCL),true)
  OBJ = obj
  SO_EXT = dll
  LIBS = -LD
- CFLAGS += -nologo -Zi -Ox /FS /MP -D__WIN32__
- CXXFLAGS += $(CFLAGS) /EHsc
+ CFLAGS += -nologo -Zi -Ox -FS -MP -D__WIN32__
+ CXXFLAGS += $(CFLAGS) -EHsc
 else
  OUT = -o
  OUT_OBJ = -o


### PR DESCRIPTION
That will enable me to keep building Wings3D from only one dev environment and should not bring any problems to other dev environments.

* @dgud, we already talked about this before by email (in June).