### PR TITLE
Checking for a previous libigl build on 'priv' folder

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -90,7 +90,13 @@ IGL_INCLUDE = -I../_deps/eigen -I../_deps/libigl/include
 
 # libigl only supports 64bits systems
 ifeq (x"${WORDSIZE}",x"64")
-    DRV = $(LIBDIR)/libigl.$(SO_EXT) $(LIBDIR)/wings_pick_nif.$(SO_EXT)
+    IGLFILE = $(LIBDIR)/libigl.$(SO_EXT)
+    ifeq ($(shell test -e $(IGLFILE) && echo -n yes),yes)
+        $(info *** Skip building LIBIGL - use 'make clean' first to rebuild it)
+        DRV = $(LIBDIR)/wings_pick_nif.$(SO_EXT)
+    else
+        DRV = $(IGLFILE) $(LIBDIR)/wings_pick_nif.$(SO_EXT)
+    endif
 else
     $(info 32bits build ignoring libigl not supported)
     DRV = $(LIBDIR)/wings_pick_nif.$(SO_EXT)


### PR DESCRIPTION
During the build/rebuld/test process of Wings3D the '**libigl**' is rebuilt
all the time if we are using make from Wings3D's root directory and/or switching
between branches. That's very annoying and it stoles from us some precious
time.
Also, if no internet connection is available the dependencies checking
seems to hang - which should also not be a problem if we already have a built
version of the library available. To update it we can just run '**make clean**'.