### PR TITLE
Fixed repeat command in AutoUV window

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -1020,7 +1020,7 @@ repeatable({scale, Dir}, Mode)
 	(Dir == normalize)) and (Mode /= body) -> false;
 repeatable({rotate, Dir}, Mode) 
   when ((Dir == align_y) or (Dir == align_x) or (Dir == align_xy)) 
-       and ((Mode == body) or (Mode == face)) -> no;
+       and ((Mode == body) or (Mode == face)) -> false;
 repeatable({move_to,_},Mode) -> Mode == body;
 repeatable({flip,_},Mode) -> Mode == body;
 repeatable(slide, Mode) -> Mode == edge;


### PR DESCRIPTION
NOTE: Alignment commands not valid for Body or Face mode was causing the AutoUV
window to crash when a repeat command was used in these modes.