### PR TITLE
Small fixes to AutoUV shader preview dialog

### DIFF
--- a/plugins_src/autouv/auv_texture.erl
+++ b/plugins_src/autouv/auv_texture.erl
@@ -207,8 +207,12 @@ option_dialog(Id, Fields, Renderers, Shaders) ->
                         Name when is_atom(Name) -> NameId = Name;
                         {_,NameId} -> NameId
                     end,
-                    {value,#sh{def=Opts0}} = lists:keysearch(NameId,#sh.id,Shaders),
-                    [{shader,NameId}|lists:reverse(Opts0)];
+                    if NameId =/= auv_edges ->
+                        {value,#sh{def=Opts0}} = lists:keysearch(NameId,#sh.id,Shaders),
+                        [{shader,NameId}|lists:reverse(Opts0)];
+                    true ->
+                        []
+                    end;
                 Opts0 ->
                     Opts0
             end,
@@ -217,10 +221,13 @@ option_dialog(Id, Fields, Renderers, Shaders) ->
                        %% Change the value in the parent dialog
                        wings_dialog:set_value({auv_opt, Id}, [Name|Res], Fields),
                        %% removing the temporary VBO data
-                       Vbo = wings_pref:get_value(?SHADER_PRW_VBO),
-                       wings_pref:delete_value(?SHADER_PRW_VBO),
-                       wings_vbo:delete(Vbo),
-                       ignore
+                       case wings_pref:get_value(?SHADER_PRW_VBO) of
+                           undefined ->  ignore;
+                           Vbo ->
+                               wings_pref:delete_value(?SHADER_PRW_VBO),
+                               wings_vbo:delete(Vbo),
+                               ignore
+                       end
                    end,
         UVSt = create_uv_state(),
         wings_dialog:dialog(StrName,options(Name,Opts,Shaders,UVSt),SetValue)

--- a/plugins_src/autouv/auv_texture.erl
+++ b/plugins_src/autouv/auv_texture.erl
@@ -12,7 +12,7 @@
 %%
 
 -module(auv_texture).
--export([get_texture/2,draw_options/1]).
+-export([get_texture/2,draw_options/1,delete_preview_vbo/0]).
 
 -define(NEED_OPENGL, 1).
 -define(NEED_ESDL, 1).
@@ -221,18 +221,22 @@ option_dialog(Id, Fields, Renderers, Shaders) ->
                        %% Change the value in the parent dialog
                        wings_dialog:set_value({auv_opt, Id}, [Name|Res], Fields),
                        %% removing the temporary VBO data
-                       case wings_pref:get_value(?SHADER_PRW_VBO) of
-                           undefined ->  ignore;
-                           Vbo ->
-                               wings_pref:delete_value(?SHADER_PRW_VBO),
-                               wings_vbo:delete(Vbo),
-                               ignore
-                       end
+                       delete_preview_vbo()
                    end,
         SphereData = create_sphere_data(),
         wings_dialog:dialog(StrName,options(Name,Opts,Shaders,SphereData),SetValue)
     catch _:Crash:ST ->
 	    io:format("EXIT: ~p ~p~n",[Crash, ST])
+    end.
+
+%% removing the temporary VBO data used by preview
+delete_preview_vbo() ->
+    case wings_pref:get_value(?SHADER_PRW_VBO) of
+        undefined ->  ignore;
+        Vbo ->
+            wings_pref:delete_value(?SHADER_PRW_VBO),
+            wings_vbo:delete(Vbo),
+            ignore
     end.
 
 %% function required to ensure a config file with image on shader can be correctly

--- a/plugins_src/autouv/shaders/edge_filter.fs
+++ b/plugins_src/autouv/shaders/edge_filter.fs
@@ -8,13 +8,33 @@
 //  See the file "license.terms" for information on usage and redistribution
 //  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
 //
-// Grabbed from tutorial By Jérôme Guinot jegx [at] ozone3d [dot] net
+// Grabbed from tutorial By JÃ©rÃ´me Guinot jegx [at] ozone3d [dot] net
 //
+#version 120
 
 varying vec2 w3d_uv;
 uniform sampler2D auv_bg;
 uniform vec2 auv_texsz;
 uniform float alpha_limit;
+
+int calc_threshold(float res)
+{
+	if (res <= 128.0) {
+		return 3;
+	} else if (res <= 256.0) {
+		return 5;
+	} else if (res <= 512.0) {
+		return 7;
+	} else if (res <= 1024.0) {
+		return 9;
+	} else if (res <= 2048.0) {
+		return 11;
+	} else if (res <= 4096.0) {
+		return 13;
+	} else {
+		return 15;
+	}
+}
 
 void main(void)
 {
@@ -23,12 +43,13 @@ void main(void)
 
     vec4 sum = vec4(0.0), tmp, result;
 
-    int f_sz = 5;
+    int f_sz = calc_threshold(max(auv_texsz.x, auv_texsz.y));
+	float div = (f_sz + 1.0)/2.0;
 
     float orig_x  = w3d_uv.x;
     float orig_y  = w3d_uv.y;
-    float orig_dw = orig_y - 2.5*step_h; // Center texel
-    float orig_lt = orig_x - 2.5*step_w; // Center texel
+    float orig_dw = orig_y - div*step_h; // Center texel
+    float orig_lt = orig_x - div*step_w; // Center texel
     float tx_weight = 0.0;
     float tx, ty;
 

--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -1972,6 +1972,9 @@ init_drawarea() ->
     {{W,75},{W,H0-100}}.
 
 cleanup_before_exit() ->
+    %% Ensure the used vbo data will be released. By canceling the Option
+    %% dialog doesn't remove it automatically.
+    auv_texture:delete_preview_vbo(),
     wings:unregister_postdraw_hook(wings_wm:this(), ?MODULE),
     wings_dl:delete_dlists().
 


### PR DESCRIPTION
- Fixed a crash caused by not checking for a valid VBO stored in pref's var;
- Fixed missing edges option (auv_edges) dialog;
- Fixed an issue with auv config file using 'image'. The code was handling an 
  image info {name,Id}, which doesn't happen when we set the image 
  name/filename or leave it empty in the auv config file;
- Sphere data for preview is now prepared once before the dialog be show;
- The create_sphere_data/0 was also adjusted to not set the #we{fs=undefined}
  because that was causing Wings3D crash when 'normal' was a requirement for
  the shader configuration;
- Fixed the edge filter offset which was letting some white lines depending on 
  the texture resolution;
- Fixed the input issue in the textbox of sliders in shader option dialog which
  was getting wrongly updated while we type the input characters;

CHECKED:
> 1) For two materials using auvBG image, after the first one get its own
>    texture it looks like the the auvBG is replaced by the new one and the
>    second material loose its temporary texture;
> 
I couldn't find a nice way to "fix" this behaviour. Usually it should happens if the user create the texture without abort it leaving the auvBG assigned to a material.

> 2) The preview sphere is getting the texture in the wrong direction, compared
>    with the result we want at the viewport.
> 
> ![Triplanar Preview-bad orientation](https://user-images.githubusercontent.com/365243/109548881-f0083c80-7aab-11eb-90c5-f6c928393642.png)
>
I gave up of figure this out. Tried a couple of things without success. It's doing what it should - just inverted in triplanar.
