### PR TITLE
Added new shader options

### DIFF
--- a/plugins_src/autouv/shaders/Makefile
+++ b/plugins_src/autouv/shaders/Makefile
@@ -40,6 +40,13 @@ FILES = standard.vs \
 	caustics.fs \
 	wpc_camouflage.auv \
 	camouflage.fs \
+	wpc_image_mixer.auv \
+	image_mixer.fs \
+	wpc_triplanar.auv \
+	triplanar.vs \
+	triplanar.fs \
+	wpc_triplanar3.auv \
+	triplanar3.fs \
 	README-shaders.txt
 
 

--- a/plugins_src/autouv/shaders/image_mixer.fs
+++ b/plugins_src/autouv/shaders/image_mixer.fs
@@ -1,0 +1,77 @@
+//
+//  image_mixer.fs --
+//
+//     Allow us to mix an image to previous layer on texture
+//
+//  Copyright (c) 2021 Micheus
+//
+//  See the file "license.terms" for information on usage and redistribution
+//  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+//
+//     $Id: image_mixer.fs,v 1.0 2021/03/11 14:00:0 micheus Exp $
+//
+
+#version 120
+
+uniform sampler2D image_mix;
+uniform sampler2D auv_bg;
+
+// input parameters from wpc_image_mixer
+uniform float rot;
+uniform float hshift;
+uniform float vshift;
+uniform float hscale;
+uniform float vscale;
+uniform bool tillable;
+uniform int mixmode;
+uniform float weight;
+
+varying vec2 w3d_uv;
+
+#define ZERO 0.0001
+#define TO_RAD  0.0174532925277778 // 1 degree => radians;
+
+
+mat2 rotateMtx2D(float rot) {
+    rot *= TO_RAD;
+    float cR = cos(rot);
+    float sR = sin(rot);
+    return mat2(cR,-sR,sR,cR);
+}
+
+vec2 transf2D(vec2 p, vec2 dom, vec2 scl, vec2 ofst, float rot) {
+    mat2 rotMtx = rotateMtx2D(rot);
+    vec2 center = vec2(0.5);  // finding the domain middle by dividing it by two
+    p -= center;
+    p *= scl;
+    p *= rotMtx;
+    p += (dom/2.0)*ofst;
+    return p+center;
+}
+
+vec4 pick_textel(sampler2D img, vec2 uv) {
+    return texture2D(img, uv);
+}
+
+
+void main( void ) {
+    vec2 scale = vec2(100.0/max(hscale,ZERO), 100.0/max(vscale,ZERO));
+    vec2 offset = vec2(hshift/-100.0, vshift/-100.0);
+    vec2 uv = transf2D(w3d_uv, vec2(1.0,1.0)*scale, scale, offset, -rot);
+    bool uni = (min(uv.x,uv.y) >= 0.0) && (max(uv.x,uv.y) <= 1.0);
+    vec4 bgCol = pick_textel(auv_bg, w3d_uv);
+    vec4 mixCol = pick_textel(image_mix, uv);
+    float mixVal = weight/100.0;
+
+    vec4 color;
+    if (!tillable && !uni) {
+        color = bgCol;
+    } else {
+        if (mixmode == 0) {  // Mix
+            color = vec4(mix(bgCol.rgb, mixCol.rgb, mixVal), mixCol.a);
+        } if (mixmode == 1) {  // Multiply
+            color = vec4(mixCol.rgb*(bgCol.rgb*mixVal), mixCol.a);
+        }
+    }
+    gl_FragColor = clamp(color,0.0,1.0);
+}

--- a/plugins_src/autouv/shaders/triplanar.fs
+++ b/plugins_src/autouv/shaders/triplanar.fs
@@ -1,0 +1,115 @@
+//  triplanar.fs --
+//
+//     Implemented the texture paint using triplanar
+//     approach by using one image.
+//
+//  Copyright (c) 2021 Micheus
+//
+//  See the file "license.terms" for information on usage and redistribution
+//  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+//
+//     $Id: triplanar.fs,v 1.0 2021/02/20 10:00:0 micheus Exp $
+//
+#version 120
+
+uniform sampler2D auv_bg;
+// input parameters from wpc_image_mixer
+uniform sampler2D image;
+
+uniform float sharpness;
+uniform float hscale;
+uniform float vscale;
+uniform float rot;
+uniform float hshift;
+uniform float vshift;
+uniform int mixmode;
+uniform float weight;
+
+uniform vec3 auv_bbpos3d[2];
+varying vec2 w3d_uv;
+varying vec3 w3d_pos;
+varying vec3 w3d_normal;
+
+#define ZERO 0.0001
+#define TO_RAD  0.0174532925277778 // 1 degree => radians;
+
+
+mat2 rotateMtx2D(float rot) {
+    rot *= TO_RAD;
+    float cR = cos(rot);
+    float sR = sin(rot);
+    return mat2(cR,-sR,sR,cR);
+}
+
+vec2 transf2D(vec2 p, vec2 dom, vec2 scl, vec2 ofst, float rot) {
+    mat2 rotMtx = rotateMtx2D(rot);
+    vec2 center = vec2(0.5);  // finding the domain middle by dividing it by two
+    p -= center;
+    p *= scl;
+    p *= rotMtx;
+    p += (dom/2.0)*ofst;
+    return p+center;
+}
+
+// "boxmap" code adapted from Inigo Quilez - BEGIN
+//
+// https://iquilezles.org/www/articles/biplanar/biplanar.htm
+//
+// "img..." texture sampler
+// "p" point apply texture to (normalized)
+// "n" normal at "p"
+// "sharp" controls the sharpness of the blending in the
+//     transitions areas.
+vec4 boxmap(sampler2D img, vec3 p, vec3 n, vec4 scloft, float rot, float sharp)
+{
+    // inverting the texture in accord with axis direction
+    vec3 inv = abs(n) / n;
+    vec2 uv_y = vec2(-inv.y*p.z, -inv.y*p.x);
+    vec2 uv_x = vec2(-inv.x*p.z, p.y);
+    vec2 uv_z = vec2(inv.z*p.x, p.y);
+
+    // sides: left-right/front-back
+    uv_x = transf2D(uv_x, vec2(1.0,1.0), scloft.xy, scloft.zw, -rot);
+    uv_z = transf2D(uv_z, vec2(1.0,1.0), scloft.xy, scloft.zw, -rot);
+    // top-bottom
+    uv_y = transf2D(uv_y, vec2(1.0,1.0), scloft.xy, scloft.zw, -rot);
+
+    // project+fetch
+    vec4 x = texture2D(img, uv_x);
+    vec4 y = texture2D(img, uv_y);
+    vec4 z = texture2D(img, uv_z);
+    // and blend
+    vec3 m = pow(abs(n), vec3(sharp));
+    return vec4((x*m.x + y*m.y + z*m.z) / (m.x + m.y + m.z));
+}
+// code adaptation - END
+
+vec4 pick_textel(sampler2D img, vec2 uv) {
+    return texture2D(img, uv);
+}
+
+
+void main() {
+    float mixVal = weight/100.0;
+    vec4 bgCol = pick_textel(auv_bg, w3d_uv);
+    // matching the 3D coordiante space to the UV space [0,1]
+    vec3 pos = (w3d_pos-auv_bbpos3d[0]) / (auv_bbpos3d[1]-auv_bbpos3d[0]);
+    vec3 nor = w3d_normal;
+
+    // packing paramters
+    vec2 scale = vec2(100.0/max(hscale,ZERO), 100.0/max(vscale,ZERO));
+    vec2 offset = vec2(hshift/-100.0, vshift/-100.0);
+    vec4 scloft = vec4(scale, offset);
+    float sharp = sharpness/10.0;
+
+    // computing the color
+    vec4 mixCol = boxmap(image, pos, nor, scloft, rot, sharp);
+
+    vec4 color;
+    if (mixmode == 0) {  // Mix
+        color = vec4(mix(bgCol.rgb, mixCol.rgb, mixVal), mixCol.a);
+    } if (mixmode == 1) {  // Multiply
+        color = vec4(mixCol.rgb*(bgCol.rgb*mixVal), mixCol.a);
+    }
+    gl_FragColor = clamp(color,0.0,1.0);
+}

--- a/plugins_src/autouv/shaders/triplanar.vs
+++ b/plugins_src/autouv/shaders/triplanar.vs
@@ -1,0 +1,33 @@
+//
+// triplanar.vs
+//
+//      Pass through vertex shader.
+//
+// Copyright (c) 2006 Dan Gudmundsson (standard.vs)
+//               2021 Micheus (adapting for triplanar)
+//
+//  See the file "license.terms" for information on usage and redistribution
+//  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+//
+//     $Id: standard.vs,v 1.2 2006/01/27 15:17:56 dgud Exp $
+//          triplanar.vs,v 1.0 2021/02/22 13:41:35 micheus Exp $
+//
+
+varying vec2 w3d_uv;
+varying vec3 w3d_pos;
+varying vec3 w3d_normal;   // world space - used by triplanar
+
+uniform vec2 auv_texsz;
+
+void main(void)
+{
+    // UV coords comes here since we are actually drawing on a texture
+    w3d_uv    = gl_Vertex.xy;
+
+    // The vertex positions comes here in world space
+    w3d_pos   = gl_MultiTexCoord1.xyz;
+    w3d_normal = gl_Normal.xyz;
+
+    vec4 Position = gl_Vertex;
+    gl_Position   = (gl_ModelViewProjectionMatrix * Position);
+}

--- a/plugins_src/autouv/shaders/triplanar3.fs
+++ b/plugins_src/autouv/shaders/triplanar3.fs
@@ -1,0 +1,133 @@
+//
+//  triplanar3.fs --
+//
+//     Implemented the texture paint using triplanar
+//     approach by using three images.
+//
+//  Copyright (c) 2021 Micheus
+//
+//  See the file "license.terms" for information on usage and redistribution
+//  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+//
+//     $Id: triplanar3.fs,v 1.0 2021/02/20 10:00:0 micheus Exp $
+//
+#version 120
+
+uniform sampler2D auv_bg;
+// input parameters from wpc_image_mixer
+uniform sampler2D imagey;
+uniform float t_sharpness;
+uniform float t_hscale;
+uniform float t_vscale;
+uniform float t_rot;
+uniform float t_hshift;
+uniform float t_vshift;
+
+uniform sampler2D imagex;
+uniform sampler2D imagez;
+uniform float s_sharpness;
+uniform float s_hscale;
+uniform float s_vscale;
+uniform float s_rot;
+uniform float s_hshift;
+uniform float s_vshift;
+
+uniform int mixmode;
+uniform float weight;
+
+uniform vec3 auv_bbpos3d[2];
+varying vec2 w3d_uv;
+varying vec3 w3d_pos;
+varying vec3 w3d_normal;
+
+#define ZERO 0.0001
+#define TO_RAD  0.0174532925277778 // 1 degree => radians;
+
+
+mat2 rotateMtx2D(float rot) {
+    rot *= TO_RAD;
+    float cR = cos(rot);
+    float sR = sin(rot);
+    return mat2(cR,-sR,sR,cR);
+}
+
+vec2 transf2D(vec2 p, vec2 dom, vec2 scl, vec2 ofst, float rot) {
+    mat2 rotMtx = rotateMtx2D(rot);
+    vec2 center = vec2(0.5);  // finding the domain middle by dividing it by two
+    p -= center;
+    p *= scl;
+    p *= rotMtx;
+    p += (dom/2.0)*ofst;
+    return p+center;
+}
+
+// "boxmap" code adapted from Inigo Quilez - BEGIN
+//
+// https://iquilezles.org/www/articles/biplanar/biplanar.htm
+//
+// "img..." texture sampler
+// "p" point apply texture to (normalized)
+// "n" normal at "p"
+// "sharp" controls the sharpness of the blending in the
+//     transitions areas.
+vec4 boxmap(sampler2D imgx, sampler2D imgy, sampler2D imgz, vec3 p,
+            vec3 n, vec4 t_scloft, vec4 s_scloft, vec2 rot, vec2 sharp)
+{
+    // inverting the texture in accord with axis direction
+    vec3 inv = abs(n) / n;
+    vec2 uv_y = vec2(-inv.y*p.z, -inv.y*p.x);
+    vec2 uv_x = vec2(-inv.x*p.z, p.y);
+    vec2 uv_z = vec2(inv.z*p.x, p.y);
+
+    // sides: left-right/front-back
+    uv_x = transf2D(uv_x, vec2(1.0,1.0), s_scloft.xy, s_scloft.zw, -rot.y);
+    uv_z = transf2D(uv_z, vec2(1.0,1.0), s_scloft.xy, s_scloft.zw, -rot.y);
+    // top-bottom
+    uv_y = transf2D(uv_y, vec2(1.0,1.0), t_scloft.xy, t_scloft.zw, -rot.x);
+
+    // project+fetch
+    vec4 x = texture2D(imgx, uv_x);
+    vec4 y = texture2D(imgy, uv_y);
+    vec4 z = texture2D(imgz, uv_z);
+    // and blend
+    vec3 m = pow(abs(n), sharp.xyx);
+    return vec4((x*m.x + y*m.y + z*m.z) / (m.x + m.y + m.z));
+}
+// code adaptation - END
+
+vec4 pick_textel(sampler2D img, vec2 uv) {
+    return texture2D(img, uv);
+}
+
+
+void main() {
+    float mixVal = weight/100.0;
+    vec4 bgCol = pick_textel(auv_bg, w3d_uv);
+    // matching the 3D coordiante space to the UV space [0,1]
+    vec3 pos = (w3d_pos-auv_bbpos3d[0]) / (auv_bbpos3d[1]-auv_bbpos3d[0]);
+    vec3 nor = w3d_normal;
+
+    // packing paramters
+    vec2 t_scale = vec2(100.0/max(t_hscale,ZERO), 100.0/max(t_vscale,ZERO));
+    vec2 t_offset = vec2(t_hshift/-100.0, t_vshift/-100.0);
+    vec4 t_scloft = vec4(t_scale, t_offset);
+
+    vec2 s_scale = vec2(100.0/max(s_hscale,ZERO), 100.0/max(s_vscale,ZERO));
+    vec2 s_offset = vec2(s_hshift/-100.0, s_vshift/-100.0);
+    vec4 s_scloft = vec4(s_scale, s_offset);
+
+    vec2 rot = vec2(t_rot, s_rot);
+    vec2 sharp = vec2(t_sharpness/10.0, s_sharpness/10.0);
+
+    // computing the color
+    vec4 mixCol = boxmap(imagex, imagey, imagez, pos, nor,
+                         t_scloft, s_scloft, rot, sharp);
+
+    vec4 color;
+    if (mixmode == 0) {  // Mix
+        color = vec4(mix(bgCol.rgb, mixCol.rgb, mixVal), mixCol.a);
+    } if (mixmode == 1) {  // Multiply
+        color = vec4(mixCol.rgb*(bgCol.rgb*mixVal), mixCol.a);
+    }
+    gl_FragColor = clamp(color,0.0,1.0);
+}

--- a/plugins_src/autouv/shaders/wpc_image_mixer.auv
+++ b/plugins_src/autouv/shaders/wpc_image_mixer.auv
@@ -1,0 +1,30 @@
+%%
+%%  wpc_image_mixer.auv --
+%%
+%%     Config file to load an image on shader and mix it to a previous layer
+%%
+%%  Copyright (c) 2021 Micheus
+%%
+%%  See the file "license.terms" for information on usage and redistribution
+%%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+%%
+%%     $Id: wpc_image_mixer.auv,v 1.0 2021/03/11 14:00:0 micheus Exp $
+%%
+
+%%  Everything behind a '%' is a comment
+
+{name, "Image Mixer"}.                  % The name in the shader selector
+{vertex_shader, "standard.vs"}.         % Vertex shader used
+{fragment_shader, "image_mixer.fs"}.    % Fragment shader used
+
+%% Uses these uniforms:
+
+{uniform, image, "image_mix", "", "Image (other them *_auv)"}.
+{uniform, {slider,0.0,1000.0}, "hscale", 100.0, "Horiz. Scale (%)"}.
+{uniform, {slider,0.0,1000.0}, "vscale", 100.0, "Vert. Scale (%)"}.
+{uniform, bool, "tillable", true, "Tillable"}.
+{uniform, {slider,-360.0,360.0}, "rot", 0.0, "Rotate"}.
+{uniform, {slider,-100.0,100.0}, "hshift", 0.0, "Horiz. Shift (%)"}.
+{uniform, {slider,-100.0,100.0}, "vshift", 0.0, "Vert. Shift (%)"}.
+{uniform, menu, "mixmode","Mix",[{"Mix",0},{"Multiply",1}]}.
+{uniform, {slider,0.0,100.0}, "weight", 50.0, "Mix Mode Weight"}.

--- a/plugins_src/autouv/shaders/wpc_tile.auv
+++ b/plugins_src/autouv/shaders/wpc_tile.auv
@@ -20,9 +20,9 @@
 %% Uses these uniforms:
 %% {uniform, Type, VarID in shader, DefaultValue, StringInGUI}
 {uniform, color, "colorTile", {0.8,0.8,0.8,1.0}, "Color"}.
-{uniform, {slider,0.0,100.0}, "scalex", 10.0, "Horiz. scale (%)"}.
-{uniform, {slider,0.0,100.0}, "scaley", 10.0, "Vert. scale (%)"}.
-{uniform, {slider,0.0,100.0}, "shift", 0.0, "Horiz. shift (%)"}.
+{uniform, {slider,0.0,100.0}, "scalex", 10.0, "Horiz. Scale (%)"}.
+{uniform, {slider,0.0,100.0}, "scaley", 10.0, "Vert. Scale (%)"}.
+{uniform, {slider,0.0,100.0}, "shift", 0.0, "Horiz. Shift (%)"}.
 {uniform, color, "colorMortar", {0.5,0.5,0.5,1.0}, "Mortar color"}.
 {uniform, {slider,0.0,100.0}, "scaleMortar", 1.0, "Mortar scale (%)"}.
 

--- a/plugins_src/autouv/shaders/wpc_triplanar.auv
+++ b/plugins_src/autouv/shaders/wpc_triplanar.auv
@@ -1,0 +1,33 @@
+%%
+%%  wpc_triplanar.auv --
+%%
+%%     Config file to load an image on shader generate a
+%%     triplanar texture using a single image
+%%
+%%  Copyright (c) 2021 Micheus
+%%
+%%  See the file "license.terms" for information on usage and redistribution
+%%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+%%
+%%     $Id: wpc_triplanar.auv,v 1.0 2021/02/20 14:00:00 micheus Exp $
+%%
+
+%%  Everything behind a '%' is a comment
+
+{name, "Triplanar (1 img)"}.       % The name in the shader selector
+{vertex_shader, "Triplanar.vs"}.   % Vertex shader used
+{fragment_shader, "Triplanar.fs"}. % Fragment shader used
+
+{requires,[normal]}.               % We require vertex normals
+{auv, auv_bbpos3d}.                % Use bounding box for positions
+
+%% Uses these uniforms:
+{uniform, image, "image", "", "Image (other them *_auv)"}.
+{uniform, {slider,0.0,100.0}, "sharpness", 80.0, "Blend Sharpness Top"}.
+{uniform, {slider,0.0,1000.0}, "hscale", 100.0, "Horiz. Scale (%)"}.
+{uniform, {slider,0.0,1000.0}, "vscale", 100.0, "Vert. Scale (%)"}.
+{uniform, {slider,-360.0,360.0}, "rot", 0.0, "Rotate"}.
+{uniform, {slider,-100.0,100.0}, "hshift", 0.0, "Horiz. Shift (%)"}.
+{uniform, {slider,-100.0,100.0}, "vshift", 0.0, "Vert. Shift (%)"}.
+{uniform, menu, "mixmode","Mix",[{"Mix",0},{"Multiply",1}]}.
+{uniform, {slider,0.0,100.0}, "weight", 50.0, "Mix Mode Weight"}.

--- a/plugins_src/autouv/shaders/wpc_triplanar3.auv
+++ b/plugins_src/autouv/shaders/wpc_triplanar3.auv
@@ -1,0 +1,43 @@
+%%
+%%  wpc_triplanar3.auv --
+%%
+%%     Config file to load an image on shader generate a
+%%     triplanar texture using three images
+%%
+%%  Copyright (c) 2021 Micheus
+%%
+%%  See the file "license.terms" for information on usage and redistribution
+%%  of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+%%
+%%     $Id: wpc_triplanar3.auv,v 1.0 2021/02/27 16:08:00 micheus Exp $
+%%
+
+%%  Everything behind a '%' is a comment
+
+{name, "Triplanar (3 img)"}.         % The name in the shader selector
+{vertex_shader, "Triplanar.vs"}.     % Vertex shader used
+{fragment_shader, "Triplanar3.fs"}.  % Fragment shader used
+
+{requires,[normal]}.                 % We require vertex normals
+{auv, auv_bbpos3d}.                  % Use bounding box for positions
+
+%% Uses these uniforms:
+{uniform, image, "imagey", "", "Top (other them *_auv)"}.
+{uniform, {slider,0.0,100.0}, "t_sharpness", 80.0, "Blend Sharpness Top"}.
+{uniform, {slider,0.0,1000.0}, "t_hscale", 100.0, "Horiz. Scale (%)"}.
+{uniform, {slider,0.0,1000.0}, "t_vscale", 100.0, "Vert. Scale (%)"}.
+{uniform, {slider,-360.0,360.0}, "t_rot", 0.0, "Rotate"}.
+{uniform, {slider,-100.0,100.0}, "t_hshift", 0.0, "Horiz. Shift (%)"}.
+{uniform, {slider,-100.0,100.0}, "t_vshift", 0.0, "Vert. Shift (%)"}.
+
+{uniform, image, "imagex", "", "Side (X axis) (other them *_auv)"}.
+{uniform, image, "imagez", "", "Side (Z axis) (other them *_auv)"}.
+{uniform, {slider,0.0,100.0}, "s_sharpness", 80.0, "Blend Sharpness"}.
+{uniform, {slider,0.0,1000.0}, "s_hscale", 100.0, "Horiz. Scale (%)"}.
+{uniform, {slider,0.0,1000.0}, "s_vscale", 100.0, "Vert. Scale (%)"}.
+{uniform, {slider,-360.0,360.0}, "s_rot", 0.0, "Rotate"}.
+{uniform, {slider,-100.0,100.0}, "s_hshift", 0.0, "Horiz. Shift (%)"}.
+{uniform, {slider,-100.0,100.0}, "s_vshift", 0.0, "Vert. Shift (%)"}.
+
+{uniform, menu, "mixmode","Mix",[{"Mix",0},{"Multiply",1}]}.
+{uniform, {slider,0.0,100.0}, "weight", 50.0, "Mix Mode Weight"}.


### PR DESCRIPTION
- Added triplanar shaders for one image and three images as input;
- New image mix shader which allow us to blend an image with the previous layer;

It requires the updates made to auv_texture module (420f822) - already approved
in order to be able to load images on Option dialog.

Note:
- Added triplanar and image mix shaders to AutoUV shaders.