### PR TITLE
Fixed shader preview crash for mirrored objects

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -488,12 +488,12 @@ command_menu(vertex, X, Y) ->
     wings_menu:popup_menu(X,Y, {auv,vertex}, Menu);
 command_menu(_, X, Y) ->
     case catch wpc_hlines:init() of
-        true -> ExportMenu = [{auv_export_menu(label), export_uv, auv_export_menu(help)}];
+        true -> ExportMenu = [separator, {auv_export_menu(label), export_uv, auv_export_menu(help)}];
         _ -> ExportMenu = []
     end,
     Checked = [{crossmark, ?GET({?MODULE,show_background})}],
     Menu = [{auv_show_menu(label),toggle_background,auv_show_menu(help),Checked}] ++
-           option_menu() ++ ExportMenu,
+           ExportMenu ++ option_menu(),
     wings_menu:popup_menu(X,Y, {auv,option}, Menu).
 
 stretch_directions() ->


### PR DESCRIPTION
During the previous commits to add the shader preview feature we started to get
and crash when an mirrored object was in use. Initially, the problem seemed to
be related to the new changes, but in fact it was sleeping. It started after a
fix that allow us to work with images in shaders, which now we can make use of
require 'normals' information.
So, the fix was just "tell" wings_we:normals/3 there is no mirror in the object
when we request it to compute the normals we need.

I noticed I did a mistake in draw_options/1 by requesting the current #st{} to
use in the dialog preview returns, as well as get_texture/2 required the AutoUV

It was also rearranged the AutoUV menu items in order to keep the Create Texture
on the menu bottom - as it used to be. This way the menu still is comfortable to
use even with the addition of the 'Export UV' added in a previous commit.