### PR TITLE
Added align option to AutoUV window

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -412,6 +412,13 @@ command_menu(body, X, Y) ->
 	       {?__(19,"Left"), left, ?__(20,"Move to left border")},
 	       {?__(21,"Right"), right, ?__(22,"Move to right border")}
 	      ]}, ?__(23,"Move charts to position")},
+	    {?__(93,"Align"),
+	     {align,
+	      [{?__(15,"Bottom"), bottom, ?__(95,"Align to bottom")},
+	       {?__(17,"Top"), top, ?__(96,"Align to top")},
+	       {?__(19,"Left"), left, ?__(97,"Align to left")},
+	       {?__(21,"Right"), right, ?__(98,"Align to right")}
+	      ]}, ?__(94,"Align charts relative each other")},
 	    {?__(24,"Flip"),{flip,
                              [{?__(25,"Horizontal"),horizontal,?__(26,"Flip selection horizontally")},
                               {?__(27,"Vertical"),vertical,?__(28,"Flip selection vertically")}]},
@@ -917,6 +924,11 @@ handle_command_1({rotate,Deg}, St0) ->
     get_event(St);
 handle_command_1({move_to,Dir}, St0) ->
     St1 = wpa:sel_map(fun(_, We) -> move_to(Dir,We) end, St0),
+    St = update_selected_uvcoords(St1),
+    get_event(St);
+handle_command_1({align,Dir}, St0) ->
+    BB = wings_sel:bounding_box(St0),
+    St1 = wpa:sel_map(fun(_, We) -> align(Dir,BB,We) end, St0),
     St = update_selected_uvcoords(St1),
     get_event(St);
 handle_command_1({flip,horizontal}, St0) ->
@@ -1789,6 +1801,18 @@ move_to(Dir,We) ->
 	      left ->     {-X1,0.0,0.0};
 	      right ->    {1.0-X2,0.0,0.0}
 	  end,
+    T = e3d_mat:translate(Translate),
+    wings_we:transform_vs(T, We).
+
+align(Dir,[{Xa,Ya,_},{Xb,Yb,_}],We) ->
+    [{X1,Y1,_},{X2,Y2,_}] = wings_vertex:bounding_box(We),
+    Translate =
+        case Dir of
+            bottom ->   {0.0,(Ya-Y1),0.0};
+            top ->      {0.0,(Yb-Y2),0.0};   
+            left ->     {(Xa-X1),0.0,0.0};
+            right ->    {(Xb-X2),0.0,0.0}
+        end,
     T = e3d_mat:translate(Translate),
     wings_we:transform_vs(T, We).
 


### PR DESCRIPTION
It's common we need to rearrange the UV islands aligned by top/left/right or
bottom. Currently, we need to use 'Move To' in order to align them to the
UV boundaries and then move back to a desired position.

NOTE:
- Added Align option to AutoUV in order to make easier to align islands to each
other.