### PR TITLE
Added option to avoid shaders to use the preview sphere in dialog

### DIFF
--- a/plugins_src/autouv/shaders/wpc_edgefilter.auv
+++ b/plugins_src/autouv/shaders/wpc_edgefilter.auv
@@ -11,13 +11,13 @@
 
 %%  Everything behind a '%' is a comment
 
-{name, "Edge Filter"}.                      % The name in the shader selector
+{name, "Edge Filter"}.                 % The name in the shader selector
 {vertex_shader, "standard.vs"}.        % Vertex shader used
-{fragment_shader, "edge_filter.fs"}.  % Fragment shader used
+{fragment_shader, "edge_filter.fs"}.   % Fragment shader used
+{preview, no}.                         % No preview for this shader
 %% Asks what data to send to the shader
 {auv, auv_bg}.                         % Work on the bg texture
 {auv, auv_texsz}.                      % vec2 width and height
 {auv, {auv_send_texture,"Filter the entire Image (required!)",true}}.
 
 {uniform, float, "alpha_limit",  0.3, "Edge have alpha above"}.
-%%

--- a/plugins_src/autouv/shaders/wpc_filter.auv
+++ b/plugins_src/autouv/shaders/wpc_filter.auv
@@ -16,6 +16,7 @@
 {name, "Filter"}.                      % The name in the shader selector
 {vertex_shader, "standard.vs"}.        % Vertex shader used
 {fragment_shader, "image_filter.fs"}.  % Fragment shader used
+{preview, no}.                         % No preview for this shader
 %% Asks what data to send to the shader
 {auv, {auv_send_texture,"Filter the entire Image",true}}. 
 {auv, auv_bg}.                         % Work on the bg texture


### PR DESCRIPTION
It was added a new paramter to the wpc_***.auv that let the code know it
doesn't requires/produce a texture preview.
It was also made some changes to prevent crashes if a shader settings previously
stored in the preferences and load in a new project references an image that is
no long available. Unfortunately, we don't have a way to know if between those
recovered parameters some of them is related to an image until we try to bind
them to the shader uniforms.
So, I splited out some functions to be reused and then we are now checking if
an image is available otherwise we replace it by the default AuvBG.