### PR TITLE
Fixed an issue with PBR material on Intel graphic driver

### DIFF
--- a/src/wings_shaders.erl
+++ b/src/wings_shaders.erl
@@ -29,6 +29,11 @@ init() ->
     wings_pref:set_default(cl_lightpos, ?cl_lightpos),
     wings_pref:set_default(cl_lightcol, {1.0,1.0,1.0}),
     wings_pref:set_default(cam_exposure, 1.0),
+    Vendor = string:tokens(string:lowercase(gl:getString(?GL_VENDOR))," "),
+    case lists:member("intel",Vendor) of
+        true -> compile_all();
+        false -> ignore
+    end,
     compile_all().
 
 compile_all() ->


### PR DESCRIPTION
This workaround prevent the bad quality on PBR material for some Intel graphic
drivers. In a mirror object the image may be too blurred.

![image1](https://user-images.githubusercontent.com/365243/114797597-eb50cc80-9d69-11eb-9237-da01d0c5b446.png)  ![image2](https://user-images.githubusercontent.com/365243/114797618-fad01580-9d69-11eb-8e1c-b642f446d000.png)
