### PR TITLE
Fixed the behaviour of visibility field for Yafaray

### DIFF
--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -853,6 +853,11 @@ material_dialog(_Name, Mat) ->
                     wings_dialog:show(?KEY(pnl_volume), Value =:= volume, Store),
                     wings_dialog:show(?KEY(pnl_mesh_light), Value =:= meshlight, Store),
                     wings_dialog:show(?KEY(pnl_lightportal), Value =:= lightportal, Store),
+                    case Value of
+                        lightportal -> wings_dialog:set_value(?KEY(visibility),normal,Store);
+                        _ -> ignore
+                    end,
+                    wings_dialog:enable(?KEY(visibility), Value =/= lightportal, Store),
                     wings_dialog:update(?KEY(pnl_obj_params), Store);
                 ?KEY(volume_type) ->
                     wings_dialog:show(?KEY(pnl_desnity_volume), Value =:= expdensityvolume, Store),


### PR DESCRIPTION
After the previous inclusion of this information in the plugin, it was noticed
the visibility property doesn't applies to the light portal material. So, it is
now disabled for that kind in order to avoid user misunderstanding.