### PR TITLE
Small adjustments to the geometry visualisation

### DIFF
--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -327,7 +327,7 @@ sel_mirror_objects(St) ->
 
 
 -define(RANGE_FOV, {1.0,179.9}).
--define(RANGE_NEAR_CLIP, {0.01,1000.0}).
+-define(RANGE_NEAR_CLIP, {0.001,1000.0}).
 -define(RANGE_FAR_CLIP, {100.0,infinity}).
 -define(RANGE_ZOOM_SLIDER, {-1.0,4.0}).
 -define(RANGE_NEGATIVE_SIZE, {1,infinity}).


### PR DESCRIPTION
- Decreased the near clipping value from 0.01 to 0.001;
This limitation has been commented time to time. I already experienced that
sometimes. So, by changing it we open the possibility to work correctly with
detailed object which has small pieces that need attention.
- Added the possibility to draw the ground grid for scales 0.1, 0.01 and 0.001;
The grid for these scales was missing.
- Adjusted the function bind for drawing the main axes. The exact 0.0 value
barely is reached and sometimes they are hidden by the grid line. That can 
be noticed on the attached image.

NOTE:
- Decreased the near clipping value from 0.01 to 0.001;
- The ground grid is also now drawn for scales as 0.1, 0.01 and 0.001;

![scale-to-0 01-grid](https://user-images.githubusercontent.com/365243/114987764-e96f3200-9e6b-11eb-829e-6cf7b0e990f1.png)
