### PR TITLE
Added MMB option to Material menu option in Face mode

### DIFF
--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -39,7 +39,7 @@ material_menu(St) ->
 material_fun(St) ->
     fun(help, _Ns) ->
 	    {?__(1,"Assign existing material to selection"),
-         ?__(3,"Edit material assigned to selection"),
+	     ?__(3,"Edit material assigned to selection"),
 	     ?__(2,"Create and assign new material")};
        (1, _Ns) ->
 	    mat_list(St);

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -38,10 +38,13 @@ material_menu(St) ->
 
 material_fun(St) ->
     fun(help, _Ns) ->
-	    {?__(1,"Assign existing material to selection"),[],
+	    {?__(1,"Assign existing material to selection"),
+         ?__(3,"Edit material assigned to selection"),
 	     ?__(2,"Create and assign new material")};
        (1, _Ns) ->
 	    mat_list(St);
+       (2, _Ns) ->
+	    mat_used_list(St);
        (3, _) ->
 	    {material,new};
        (_, _) -> ignore
@@ -56,6 +59,19 @@ mat_list_1([{Name,Ps}|Ms], Acc) ->
     Menu = {atom_to_list(Name),{assign,Name},[],[{color,Diff}]},
     mat_list_1(Ms, [Menu|Acc]);
 mat_list_1([], Acc) -> reverse(Acc).
+
+mat_used_list(St) ->
+    MatList =
+        wings_sel:fold(fun(Sel,We,Acc) ->
+            gb_sets:fold(fun(F,Acc0)->
+                MatName = atom_to_list(wings_facemat:face(F,We)),
+                case lists:member(MatName,Acc0) of
+                    false -> [MatName|Acc0];
+                    true -> Acc0
+                end
+            end, Acc, Sel)
+        end, [], St),
+    [{MatName,{'VALUE',{material,{edit,MatName}}},[]} || MatName <- MatList].
 
 new(_) ->
     new_1(new).

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -71,7 +71,10 @@ mat_used_list(St) ->
                 end
             end, Acc, Sel)
         end, [], St),
-    [{MatName,{'VALUE',{material,{edit,MatName}}},[]} || MatName <- MatList].
+    case length(MatList) of
+        1 -> {material,{edit,lists:nth(1,MatList)}};
+        _ -> [{MatName,{'VALUE',{material,{edit,MatName}}},[]} || MatName <- MatList]
+    end.
 
 new(_) ->
     new_1(new).


### PR DESCRIPTION
When working with many material it would be faster just select a piece of
the object and pick the material to be edited. The MMB option added to
the Material menu option in Face mode will allow this by complementing the
other options: Create and Assign;

NOTE:
- Added MMB option to Material menu item when Geometry window is in Face
  selection mode. Thanks Hank for the suggestion.