### PR TITLE
Added save and load feature to AutoUV texture shader

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -539,6 +539,8 @@ max_uniform() ->
 
 option_menu() ->
     [separator,
+     {?__(3,"Load Draw Options..."),load_texture,?__(4,"Load a saved texture draw settings")},
+     separator,
      {?__(1,"Create Texture"),create_texture,?__(2,"Make and Attach a texture to the model")}].
 
 %%% Event handling
@@ -656,6 +658,11 @@ handle_event_3({drop,DropData}, St) ->
 handle_event_3({action,{{auv,_},create_texture}}, St) ->
     ?SET({?MODULE,show_background}, true),
     auv_texture:draw_options(St);
+handle_event_3({action,{{auv,_},load_texture}}, _) ->
+    auv_texture:load_draw_options();
+handle_event_3({action,{auv,{draw_options_loaded,ShLib}}}, St) ->
+    ?SET({?MODULE,show_background}, true),
+    auv_texture:draw_options_loaded(ShLib,St);
 handle_event_3({action,{auv,{draw_options,restart}}}, St) ->
     ?SET({?MODULE,show_background}, true),
     auv_texture:draw_options(St);

--- a/src/wings_image.erl
+++ b/src/wings_image.erl
@@ -326,11 +326,11 @@ handle_call({update,Id,Image}, _From, S) ->
             {reply, error, S}
     end;
 handle_call({find_image, Dir, File}, _From, #ist{images=Ims}=S) ->
-    AbsName = filename:join(Dir, File),
+    AbsName = filename:nativename(filename:join(Dir, File)),
     Find = case os:type() of
                {win32, _} ->
                    fun(none) -> false;
-                      (Fn) -> string:casefold(Fn) == string:casefold(AbsName) 
+                      (Fn) -> string:casefold(Fn) == string:casefold(AbsName)
                    end;
                _ ->
                    fun(Fn) -> Fn == AbsName end


### PR DESCRIPTION
It was necessary to apply the _filename:nativename/1_ in the
_wings_image:find_image/1_ in order to get the correct file format for comparison.
It was also made two fixes:
 - a crash introduced with the use of _string:casefold/1_ which
   doesn't handle 'none'. It can happen when a new image for texture was just
   created;
 - a crash when an OpenGL error is fired and the text formatting in the
   message was not in accord with the parameter type.

NOTE:
- Added option to save and load texture settings in AutoUV window.
  Texture settings can now be reused for other projects.