### PR TITLE
Fixed a crash caused by checking image name

### DIFF
--- a/src/wings_image.erl
+++ b/src/wings_image.erl
@@ -327,9 +327,12 @@ handle_call({update,Id,Image}, _From, S) ->
     end;
 handle_call({find_image, Dir, File}, _From, #ist{images=Ims}=S) ->
     AbsName = filename:join(Dir, File),
+    io:format("AbsName: ~p\n",[AbsName]),
     Find = case os:type() of
                {win32, _} ->
-                   fun(Fn) -> string:casefold(Fn) == string:casefold(AbsName) end;
+                   fun(none) -> false;
+                      (Fn) -> string:casefold(Fn) == string:casefold(AbsName) 
+                   end;
                _ ->
                    fun(Fn) -> Fn == AbsName end
            end,


### PR DESCRIPTION
Sometimes when the image list has an image with name is 'none' Wings3D is going
to hard crash. That was introduced in the current version when it was tried to
improve the evaluation for an already loaded image.

NOTE: Fixed a crash caused by checking image name. Thanks to rgcotl (at Discord)


OBS: In fact, this fix was in the PR #466 not included in the latest release.