### PR TITLE
fix misc. typos

### DIFF
--- a/CodingGuidelines
+++ b/CodingGuidelines
@@ -319,7 +319,7 @@ And now over to more concrete rules:
          cmp(A, B) when A == B -> equal;
          cmp(A, B when A > B -> greater.
 
-  the operator in the second cluase must be '==' and not '=:='.
+  the operator in the second clause must be '==' and not '=:='.
   If the function was defined like this
 
          bad_cmp(A, B) when A < B -> less;

--- a/e3d/e3d__tri_quad.erl
+++ b/e3d/e3d__tri_quad.erl
@@ -510,7 +510,7 @@ revecheck(E={A,B}, TD, Bord, Vtab, Acc) ->
 
 %% If E is a non-border edge, with left-face triangle Tl and
 %% right-face triangle Tr, then it is "reversed" if the circle through
-%% A, B, and (say) the other vertex of Tl containts the other vertex of Tr.
+%% A, B, and (say) the other vertex of Tl contains the other vertex of Tr.
 isreversed(E={A,B}, TD, Bord, Vtab) ->
     case gb_sets:is_member(E, Bord) of
 	true -> false;

--- a/e3d/e3d_tds.erl
+++ b/e3d/e3d_tds.erl
@@ -708,7 +708,7 @@ make_chunk(Tag, Contents) when is_list(Contents) ->
     make_chunk(Tag, list_to_binary(Contents)).
 
 %%%
-%%% Create smoothing groups from the hard egdes.
+%%% Create smoothing groups from the hard edges.
 %%%
 
 assign_smooth_groups(#e3d_mesh{fs=Fs0,he=[]}=Mesh) ->

--- a/plugins_src/autouv/auv_texture.erl
+++ b/plugins_src/autouv/auv_texture.erl
@@ -503,7 +503,7 @@ option_hook(Id,Renderers,Shaders) ->
      fun(_Key, button_pressed, Fields) ->
 	     Env = wx:get_env(),
 	     spawn(fun() ->
-			   %% Neeed open dialog in dialog from another process
+			   %% Need open dialog in dialog from another process
 			   wx:set_env(Env),
 			   option_dialog(Id, Fields, Renderers, Shaders),
                            wings_wm:psend(send_once, dialog_blanket, preview)

--- a/plugins_src/autouv/shaders/README-shaders.txt
+++ b/plugins_src/autouv/shaders/README-shaders.txt
@@ -30,7 +30,7 @@ gl_Normal.  'binormal' are sent through 'gl_MultiTexCoord2.xyz'.
 
 Other options:  Sent as uniforms
 {auv, auv_bg}.    % sampler2D image of the previous pass
-{auv, auv_txsz}.  % vec2 width and heigth of image
+{auv, auv_txsz}.  % vec2 width and height of image
 {auv, {auv_send_texture,"UserQuestion",true}}.    % Float 1.0 (true) or 0.0 (false) 
 % Asks user if we should work on whole image or only the selected chart parts, sent as float 1.0 or 0.0.
 {auv, auv_bbpos3d}. % Vec3[2] The Min and Max coords of the rendered charts

--- a/plugins_src/autouv/shaders/triplanar.fs
+++ b/plugins_src/autouv/shaders/triplanar.fs
@@ -92,11 +92,11 @@ vec4 pick_textel(sampler2D img, vec2 uv) {
 void main() {
     float mixVal = weight/100.0;
     vec4 bgCol = pick_textel(auv_bg, w3d_uv);
-    // matching the 3D coordiante space to the UV space [0,1]
+    // matching the 3D coordinate space to the UV space [0,1]
     vec3 pos = (w3d_pos-auv_bbpos3d[0]) / (auv_bbpos3d[1]-auv_bbpos3d[0]);
     vec3 nor = w3d_normal;
 
-    // packing paramters
+    // packing parameters
     vec2 scale = vec2(100.0/max(hscale,ZERO), 100.0/max(vscale,ZERO));
     vec2 offset = vec2(hshift/-100.0, vshift/-100.0);
     vec4 scloft = vec4(scale, offset);

--- a/plugins_src/autouv/shaders/triplanar3.fs
+++ b/plugins_src/autouv/shaders/triplanar3.fs
@@ -103,11 +103,11 @@ vec4 pick_textel(sampler2D img, vec2 uv) {
 void main() {
     float mixVal = weight/100.0;
     vec4 bgCol = pick_textel(auv_bg, w3d_uv);
-    // matching the 3D coordiante space to the UV space [0,1]
+    // matching the 3D coordinate space to the UV space [0,1]
     vec3 pos = (w3d_pos-auv_bbpos3d[0]) / (auv_bbpos3d[1]-auv_bbpos3d[0]);
     vec3 nor = w3d_normal;
 
-    // packing paramters
+    // packing parameters
     vec2 t_scale = vec2(100.0/max(t_hscale,ZERO), 100.0/max(t_vscale,ZERO));
     vec2 t_offset = vec2(t_hshift/-100.0, t_vshift/-100.0);
     vec4 t_scloft = vec4(t_scale, t_offset);

--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -506,8 +506,8 @@ command_menu(_, X, Y) ->
 stretch_directions() ->
     [{?__(1,"Max Uniform"), max_uniform(),
       {?__(2,"Maximize either horizontally or vertically"),
-       ?__(7,"Maximize by using the horizontal dimention"),
-       ?__(8,"Maximize by using the vertical dimention")}, []},
+       ?__(7,"Maximize by using the horizontal dimension"),
+       ?__(8,"Maximize by using the vertical dimension")}, []},
      {?__(3,"Max Horizontal"), max_x, ?__(4,"Maximize horizontally (X dir)")},
      {?__(5,"Max Vertical"),   max_y, ?__(6,"Maximize vertically (Y dir)")}].
 

--- a/plugins_src/commands/wpc_circularise.erl
+++ b/plugins_src/commands/wpc_circularise.erl
@@ -489,7 +489,7 @@ check_vertex_order(Vs, Axis1, Axis2) ->
        true -> lists:reverse(Vs)
     end.
 
-%% Differenciate between Lmb and Rmb Arc commands
+%% Differentiate between Lmb and Rmb Arc commands
 check_plane(Vs, We) ->
     Normals = normals_for_surrounding_faces(Vs, We, []),
     e3d_vec:average(Normals).

--- a/plugins_src/commands/wpc_intersect_edge.erl
+++ b/plugins_src/commands/wpc_intersect_edge.erl
@@ -14,7 +14,7 @@
 %%
 %%  2000-10-09:  Fixed undo bug (had forgotten to use "{save_state, ...}")
 %%  2000-10-01:  Incorporated help text suggestions from Puzzled Paul
-%%  2000-09-21:  Normalized line direction (so lineDotPlane dependant only on
+%%  2000-09-21:  Normalized line direction (so lineDotPlane dependent only on
 %%               angle, not size of LD vector)
 %%  2000-09-17:  Tried to make more compliant w/ wings API (Paul Molodowitch)
 %%  2000-09-17:  Allowed more than one edge per body (though none can share

--- a/plugins_src/import_export/collada_import.erl
+++ b/plugins_src/import_export/collada_import.erl
@@ -899,7 +899,7 @@ test() ->
 -endif.
 
 %%%%
-%%%%   Provisory convertion from UTF16/32 - it make possible load a file
+%%%%   Provisory conversion from UTF16/32 - it make possible load a file
 %%%%   which materials name/id uses unicode
 %%%%   reported in: http://www.wings3d.com/forum/showthread.php?tid=2321
 atom_name(Name) ->

--- a/plugins_src/import_export/wpc_ai.erl
+++ b/plugins_src/import_export/wpc_ai.erl
@@ -400,7 +400,7 @@ getpas(I,N,Contd,Cct,{Pas,Ass}=Acc) ->
 	    end
     end.
 
-%% Return true if thre is no unassigned J <= second arg, J /= I,
+%% Return true if there is no unassigned J <= second arg, J /= I,
 %% such that contour J contains contour I.
 isboundary(_I,0,_Contd,_Ass) -> true;
 isboundary(I,I,Contd,Ass) -> isboundary(I,I-1,Contd,Ass);

--- a/plugins_src/import_export/wpc_hlines.erl
+++ b/plugins_src/import_export/wpc_hlines.erl
@@ -785,7 +785,7 @@ do_export(Props, File_name, #e3d_file{objs=Objs, mat=Mats}) ->
 		    %% Begin Draw Edge
 
 		    foldl(fun({ Line_code, {Line_width ,Edges, Line_color,Line_pattern} }, {Group_count, Edge_count0}) ->
-				  %% Line code is only acces dictionary
+				  %% Line code is only access dictionary
 				  {Ls0, Edge_count} = foldl(fun(EVIt, {Ls_acc0, Edge_count_acc0}) ->
 								    EVCt = vct(EVIt, VC_tree),
 								    {Ls_acc, Edge_count_acc} =
@@ -2498,7 +2498,7 @@ write_svg_header(F, {Wbb, Hbb}, Line_cap, Mats_dict, {Shade,_Lpos}) ->
     case get_pref(responsive, ?DEF_RESPONSIVE) of true -> ok;false -> io:fwrite(F, " width=\"~w" ++ "px\" height=\"~w" ++ "px\" " , [ round(Wbb),round(Hbb)]) end,
 
     io:fwrite(F, " viewBox=\"~w ~w ~w ~w\" style=\"enable-background:new 0 0 ~w ~w;\"~n" , [0, 0, round(Wbb), round(Hbb), round(Wbb), round(Hbb)]),
-    io:put_chars(F, " stroke=\"black\""), % storoke = "currentColor" cant work LibreOfficeDraw
+    io:put_chars(F, " stroke=\"black\""), % storoke = "currentColor" can't work in LibreOfficeDraw
     case Line_cap of
 	0 -> ok;
 	_ ->

--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -4,7 +4,7 @@
 %%     YafaRay Plugin User Interface, for YafaRay Core v3.1.0
 %%
 %%  Copyright (c) 2003-2008 Raimo Niskanen
-%%                2013-2015 Code Convertion from Yafray to YafaRay by Bernard Oortman (Wings3d user oort)
+%%                2013-2015 Code Conversion from Yafray to YafaRay by Bernard Oortman (Wings3d user oort)
 %%                2015 Micheus (porting to use wx dialogs)
 %%                2016 David Bluecame (adaptation for YafaRay Core v3.1.0)
 %%
@@ -910,7 +910,7 @@ material_dialog(_Name, Mat) ->
                     wings_dialog:show(?KEY(pnl_on), is_member(Value, [shinydiffuse,glossy,coatedglossy]), Store),
                     %% Fresnel Effect
                     wings_dialog:show(?KEY(pnl_fe), Value =:= shinydiffuse, Store),
-                    %% Ligth Material: Color & Power
+                    %% Light Material: Color & Power
                     wings_dialog:show(?KEY(pnl_lm), Value =:= lightmat, Store),
                     %% Blend: Material 1, Material 2 & Blend Mix
                     wings_dialog:show(?KEY(pnl_bl), Value =:= blend_mat, Store),
@@ -1668,7 +1668,7 @@ modulator_init(Mode) ->
 
 
 %%%
-%%% Ligth dialogs
+%%% Light dialogs
 %%%
 light_dialog(Name, Ps) ->
     OpenGL = proplists:get_value(opengl, Ps, []),
@@ -2368,7 +2368,7 @@ export_dialog_qs(Op, Attr) ->
                 %% SPPM - GI
                 wings_dialog:show(?KEY(pnl_sppm1), Value =:= sppm, Store),
 
-                %% 2rd column of panels
+                %% 2nd column of panels
                 %% Direct Light
                 wings_dialog:enable(?KEY(pnl_use_ao), wings_dialog:get_value(do_ao, Store) =:= true, Store),
                 wings_dialog:show(?KEY(pnl_ao), Value =:= directlighting, Store),
@@ -6212,7 +6212,7 @@ help(text,{light,ambient}) ->
 help(text,{light,area}) ->
     [[{bold,?__(80,"Area Light")}],
         ?__(81,"A rectangular light with rays emitting from the entire surface. Use for "
-        "light coming through a window or florescent ceiling lights.\n"
+        "light coming through a window or fluorescent ceiling lights.\n"
         "Wings3D objects can be converted to Area Lights with the Object to Area Light "
         "command. Expect longer render times when using Area Lights.")];
 

--- a/plugins_src/primitives/wpc_tt.erl
+++ b/plugins_src/primitives/wpc_tt.erl
@@ -524,7 +524,7 @@ getpas(I,N,Contd,Cct,{Pas,Ass}=Acc) ->
 	    end
     end.
 
-%% Return true if thre is no unassigned J <= second arg, J /= I,
+%% Return true if there is no unassigned J <= second arg, J /= I,
 %% such that contour J contains contour I.
 isboundary(_I,0,_Contd,_Ass) -> true;
 isboundary(I,I,Contd,Ass) -> isboundary(I,I-1,Contd,Ass);
@@ -1407,7 +1407,7 @@ get_glyph_shape_tt(TTF = #ttf_info{data=Bin}, _Glyph, Offset) ->
 	    N = length(Flags),
 	    setup_vertices(Flags, XCs, YCs, GlyphDesc);
        NumberOfContours =:= -1 ->
-	    %% Several Glyphs (Compund shapes)
+	    %% Several Glyphs (Compound shapes)
 	    get_glyph_shapes(GlyphDesc, TTF, []);
        NumberOfContours < -1 ->
 	    throw({error, bad_ttf, ?__(1, "Unsupported TTF format")});
@@ -1527,7 +1527,7 @@ get_glyph_shapes(<<Flags:?S16, GidX:?S16, GlyphDesc0/binary>>, Font, Vs0) ->
     Vs1 = get_glyph_shape(Font, GidX),
     Vs = scale_vertices(Vs1, ScaleInfo, Vs0),
     case (Flags band (1 bsl 5)) > 1 of
-	true -> %% More Compontents
+	true -> %% More Components
 	    get_glyph_shapes(GlyphDesc, Font, Vs);
 	false ->
 	    lists:reverse(Vs)

--- a/shaders/camera_light.fs
+++ b/shaders/camera_light.fs
@@ -23,7 +23,7 @@ void main(void)
     vec4 baseColor = get_basecolor();
     vec3 n = get_normal();
     vec3 v = normalize(ws_eyepoint-ws_position);  // point to camera
-    vec3 l = normalize(ws_lightpos-ws_position);  // point to ligth
+    vec3 l = normalize(ws_lightpos-ws_position);  // point to light
     PBRInfo pbr = calc_views(n, v, l);
     pbr = calc_material(pbr);
 

--- a/src/jsone.erl
+++ b/src/jsone.erl
@@ -202,7 +202,7 @@
 %% `canonical_form': <br />
 %% - produce a canonical form of a JSON document <br />
 %%
-%% `{float_format, Optoins}':
+%% `{float_format, Options}':
 %% - Encodes a `float()` value in the format which specified by `Options' <br />
 %% - default: `[{scientific, 20}]' <br />
 %%
@@ -219,7 +219,7 @@
 %% - NOTE: If `scalar' or `value' option is specified, non `json_string()' key will be automatically converted to a `binary()' value (e.g. `1' => `<<"1">>', `#{}' => `<<"{}">>') <br />
 %%
 %% `{space, N}': <br />
-%% - Inserts `N' spaces after every commna and colon <br />
+%% - Inserts `N' spaces after every comma and colon <br />
 %% - default: `0' <br />
 %%
 %% `{indent, N}': <br />

--- a/src/libigl.erl
+++ b/src/libigl.erl
@@ -22,7 +22,7 @@
 -type energy_type() :: 'arap' | 'log_arap' | 'symmetric_dirichlet' |
                        'conformal' | 'exp_conformal' | 'exp_symmetric_dirichlet'.
 
-%% Least sqaure conformal maps
+%% Least square conformal maps
 %% At least bind two BorderVs with UV-positions in BorderPos
 -spec lscm(Vs::[e3d_vec:point()],Fs::triangles(),[BVs::integer()], BPos::[point2d()]) ->
           [point2d()] | {'error', term()} | 'false'.
@@ -39,7 +39,7 @@ harmonic(_Vs,_Fs,_BorderVs,_BorderPos) ->
 
 
 %% Slim Scalable Locally Injective Mappings
-%% UVInitPos must contain an intial (non-flipped) UV-mapping of all verts
+%% UVInitPos must contain an initial (non-flipped) UV-mapping of all verts
 %% Stops when change is less then eps
 -spec slim(VS::[e3d_vec:point()], Fs::triangles(),
            UVInitPos::[point2d()], energy_type(), Eps::float()) -> [point2d()].

--- a/src/wings_camera.erl
+++ b/src/wings_camera.erl
@@ -729,7 +729,7 @@ generic_event(#mousewheel{dir=hor, wheel=N, mod=Mod}, _Camera, _Redraw) ->
             whpan(N/20.0,0.0);
         Mod band ?ALT_BITS =/= 0 ->
             whrotate(0.0,N/2.0);
-        true ->  %% rotate X wether SHIFT is pressed or not
+        true ->  %% rotate X whether SHIFT is pressed or not
             do_whrotate(N/2.0,0.0)
     end;
 generic_event(grab_lost, Camera, _Redraw) ->

--- a/src/wings_collapse.erl
+++ b/src/wings_collapse.erl
@@ -407,8 +407,8 @@ collapse_connect_1(Face, [Va,Vb], {EdgeA,EdgeB}, #we{es=Etab}=We0) ->
 	    %% collapsed will not be part of it), and the new face
 	    %% inside (two original edges, soon to be dissolved, and
 	    %% the new edge will surround the new face). This is
-	    %% particularily important when the existing face is a
-	    %% hole (the hole face would dissappear or shrink to a
+	    %% particularly important when the existing face is a
+	    %% hole (the hole face would disappear or shrink to a
 	    %% triangle if it is placed inside).
 	    %%
 	    case array:get(EdgeA, Etab) of
@@ -530,7 +530,7 @@ delete_if_bad(Face, #we{fs=Ftab,es=Etab}=We) ->
 	none -> We
     end.
 
-%% Remove holes refering to faces that no longer exist.
+%% Remove holes referring to faces that no longer exist.
 
 remove_bad_holes(#we{fs=Ftab,holes=Holes0}=We) ->
     Holes = ordsets:intersection(gb_trees:keys(Ftab), Holes0),

--- a/src/wings_color.erl
+++ b/src/wings_color.erl
@@ -1,7 +1,7 @@
 %%
 %%  wings_color.erl --
 %%
-%%     Color utilites.
+%%     Color utilities.
 %%
 %%  Copyright (c) 2001-2011 Bjorn Gustavsson
 %%
@@ -215,7 +215,7 @@ convert_hsv(H,V,Min) ->
     {Mean,V,Min}.
 
 %%%
-%%% Local functions for color choser.
+%%% Local functions for color chooser.
 %%%
 
 choose_1(RGB0, Done, true) ->

--- a/src/wings_convert.escript
+++ b/src/wings_convert.escript
@@ -1,6 +1,6 @@
 #!/usr/bin/env escript
 %%   -*- erlang -*-
-%%     Wings 3D File convertion.
+%%     Wings 3D File conversion.
 %%
 %%  Copyright (c) 2010 Dan Gudmundsson
 %%
@@ -21,7 +21,7 @@
 	 image_format,    %% Image out format
 	 in_formats=[],   %% Scanned, all import formats
 	 out_formats=[],  %% Scanned, all export formats
-	 modify=[]        %% Convertion modifications
+	 modify=[]        %% Conversion modifications
 	}).
 
 -record(format,

--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -228,7 +228,7 @@ dialog_preview(Cmd, Bool, Title, Qs, St) ->
     dialog_1(Bool, Title, preview, Qs, preview_fun(Cmd, St)).
 
 %% Currently a modal dialog
-%%   (orginal wings let camera events trough)
+%%   (original wings let camera events through)
 ask(Title, Qs0, Fun) ->
     {PreviewCmd, Qs} = preview_cmd(Qs0),
     dialog_1(true, Title, PreviewCmd, queries(Qs), Fun).

--- a/src/wings_dissolve.erl
+++ b/src/wings_dissolve.erl
@@ -265,7 +265,7 @@ any_duplicates([_], _) -> false;
 any_duplicates([{V,_}|Es], _) -> any_duplicates(Es, V).
 
 %% outer_edge_partition(FaceSet, WingedEdge) -> [[Edge]].
-%%  Partition the outer edges of the FaceSet. Each partion
+%%  Partition the outer edges of the FaceSet. Each partition
 %%  of edges form a closed loop with no repeated vertices.
 %%    Outer edges are edges that have one face in FaceSet
 %%  and one outside.

--- a/src/wings_drag.erl
+++ b/src/wings_drag.erl
@@ -652,7 +652,7 @@ handle_drag_event_0(Cancel, #drag{})
 handle_drag_event_0(#mousebutton{button=3,state=?SDL_RELEASED},
 		  #drag{rmb_timer=StartTime}=Drag) when StartTime =/= 0 ->
     %% When Rmb is released we subtract the StartTime (when the Rmb was pressed)
-    %% from the Stop time (relased) and if the result is less than 500000 ms, then
+    %% from the Stop time (released) and if the result is less than 500000 ms, then
     %% we cancel the drag. If not we continue the drag using the 
     Stop = os:timestamp(),
     Time = timer:now_diff(Stop, StartTime),

--- a/src/wings_draw.erl
+++ b/src/wings_draw.erl
@@ -683,7 +683,7 @@ split_new_normals(Ftab, #dlo{ns=Ns0,src_we=We}=D) ->
 
 split_new_normals([{Face,Edge}|T], We, none) ->
     %% No normals means that a new object was created in an
-    %% interative command (Shell Extrude).
+    %% interactive command (Shell Extrude).
     Ps = wings_face:vertex_positions(Face, Edge, We),
     Ns = array:set(Face, face_ns_data(Ps), array:new()),
     split_new_normals(T, We, Ns);

--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -386,8 +386,8 @@ slide(St0) ->
     State = {Mode,none,Stop},
     SUp = SDown = SN = SBi = {0.0,0.0,0.0},
 
-    %% FIXME: The use of the process dicationary (wings_slide) will
-    %% not work when each #we{} are stored in its own process.
+    %% FIXME: The use of the process dictionary (wings_slide) will
+    %% not work when each #we{} is stored in its own process.
     %%
     %% FIXME: Someone who understands the Up, Dw, N, and Bi parameters
     %% should rewrite this code in a way that can be parallelized

--- a/src/wings_help.erl
+++ b/src/wings_help.erl
@@ -217,7 +217,7 @@ performance_tips(Head) ->
 
 	   ?__(11,"Make sure that Geometry windows don't overlap."),
 
-	   ?__(12,"Use as few (active) lights as possible. More lights means less speed on most grahics cards."),
+	   ?__(12,"Use as few (active) lights as possible. More lights means less speed on most graphics cards."),
 
 	   ?__(13,"If possible, use the ")
 	   ++cmd([?__(14,"Tools"),

--- a/src/wings_light.erl
+++ b/src/wings_light.erl
@@ -975,7 +975,7 @@ load_area_light_tab() ->
     {areamatrix_tex, ImId}.
 
 fake_envmap(EnvImgRec) ->
-    %% Poor mans version with blured images
+    %% Poor mans version with blurred images
     Path = filename:join(wings_util:lib_dir(wings), "textures"),
     SpecBG = wings_image:e3d_to_wxImage(EnvImgRec),
     wxImage:rescale(SpecBG, 512, 256, [{quality, ?wxIMAGE_QUALITY_HIGH}]),
@@ -1305,9 +1305,9 @@ menu(X, Y, St) ->
 		  ?__(11,"Interactively adjust how much light weakens as it travels away from its source (quadratic factor)")}]}}},
 	     {SpotOnly,separator},
 	     {SpotOnly,{?__(12,"Spot Angle"),spot_angle,
-			?__(13,"Interactivly adjust the angle of the spotlight cone")}},
+			?__(13,"Interactively adjust the angle of the spotlight cone")}},
 	     {SpotOnly,{?__(14,"Spot Falloff"),spot_falloff,
-			?__(15,"Interactivly adjust how much light weakens farther away from the center of the spotlight cone")}},
+			?__(15,"Interactively adjust how much light weakens farther away from the center of the spotlight cone")}},
 	     {One,separator},
 	     {One,{?__(16,"Edit Properties..."),edit,
 		   ?__(17,"Edit light properties")}}|body_menu(Dir, St)],
@@ -1319,7 +1319,7 @@ body_menu(Dir, #st{selmode=body}) ->
      {?STR(menu,18,"Duplicate"),{duplicate,Dir},
       ?STR(menu,19,"Duplicate and move selected lights")},
      {?STR(menu,20,"Delete"),delete,
-      ?STR(menu,21,"Delete seleced lights")}];
+      ?STR(menu,21,"Delete selected lights")}];
 body_menu(_, _) -> [].
 
 filter_menu(Menu, St) ->

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -642,7 +642,7 @@ is_mat_transparent(Mat) ->
 %%     Attr = color|uv|tangent
 %%  Return a ordered list of the type of attributes that are needed
 %%  according to the materials.
-%%  tanget requires uv since it needs the uv's to calculate tanget space
+%%  tangent requires uv since it needs the uv's to calculate tangent space
 needed_attributes(We, #st{mat=Mat}) ->
     Used = wings_facemat:used_materials(We),
     needed_attributes_1(Used, Mat, false, false, false).

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -212,7 +212,7 @@ setup_dialog(Parent, Entries, Magnet, {X,Y} = ScreenPos, Cache) ->
             MenuData = do_setup_dialog(TopParent, Entries, Magnet, ScreenPos),
             case maps:get(overlay, MenuData) of
                 none ->
-                    %% Note we leak popup windows menues here,
+                    %% Note we leak popup windows menus here,
                     %% like autouv, should it be cleaned up?
                     ?SET(menu_cache, Cache#{{Entries, TopParent} => MenuData});
                 _ ->  %% Only for popuptransient windows
@@ -427,7 +427,7 @@ fit_menu_on_display(Frame,{MX,MY} = Pos) ->
     wxDisplay:destroy(Display),
     {PX,PY}.
 
-%% If the mouse is not moved after popping up the menu, the meny entry
+%% If the mouse is not moved after popping up the menu, the menu entry
 %% is not active, find_active_panel finds the active row.
 find_active_panel(Panel, MX, MY) ->
     {_,_,WinW,WinH} = wxWindow:getRect(Panel),

--- a/src/wings_pref.erl
+++ b/src/wings_pref.erl
@@ -334,7 +334,7 @@ defaults() ->
      %% Advanced menus are always turned on now.
      %% The default must still be false for compatibility
      %% with older Wings versions. (We force it to true
-     %% later after laoding the user's preference file.)
+     %% later after loading the user's preference file.)
      {advanced_menus,false},
      {no_basic_menu_info,true},
 

--- a/src/wings_pref_dlg.erl
+++ b/src/wings_pref_dlg.erl
@@ -506,7 +506,7 @@ misc_prefs() ->
 		      ?__(20,"Decreases large jumps in mouse coordinate changes")},
                      {no_warp,
                       ?__(31,"Camera moves and interactive commands not working"),
-		      ?__(32,"Minimize mouse moves programatically")},
+		      ?__(32,"Minimize mouse moves programmatically")},
 		     {ungrab_bug,
 		      ?__(26,"Camera moves steals focus"),
 		      ?__(27,"Problem occurs on linux")}

--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -793,6 +793,6 @@ translation_string(materials_to_colors)  -> ?__(288,"Materials to Colors");
 %%%%   Translation strings used so far 1 - 290
 %%%%
 
-%%%% Others as yet to be added are proccessed here
+%%%% Others as yet to be added are processed here
 translation_string(Atom) when is_atom(Atom) ->
     wings_util:cap(atom_to_list(Atom)).

--- a/src/wings_va.erl
+++ b/src/wings_va.erl
@@ -351,7 +351,7 @@ vtx_attrs(V, Face, #we{lv=Lva,rv=Rva}=We) ->
 %%     What = uv | color | [vertex|uv] | [vertex|color]
 %%     Attrs = opaque representation of attributes
 %%   Given Attrs, an opaque collection of attributes,
-%%   retrive the attribute given by What.
+%%   retrieve the attribute given by What.
 %%
 -spec attr('uv' | 'color', all_attributes()) -> term().
 attr(uv, [_|UV]) -> UV;

--- a/src/wings_vertex.erl
+++ b/src/wings_vertex.erl
@@ -110,7 +110,7 @@ other(V, #edge{vs=V,ve=Other}) -> Other;
 other(V, #edge{ve=V,vs=Other}) -> Other.
 
 %% pos(Vertex, VtabOrWe) -> {X,Y,Z}
-%%  Return the three co-ordinates for a vertex.
+%%  Return the three coordinates for a vertex.
 pos(V, #we{vp=Vtab}) ->
     array:get(V, Vtab);
 pos(V, Vtab) ->
@@ -245,7 +245,7 @@ connect(Face, Vs, #we{} = We0) ->
 	#we{} = We -> We
     end.
 
-%% Connect Va to Vb, maybe trough several faces.
+%% Connect Va to Vb, maybe through several faces.
 %% Return {#we{},gbset(Edges).
 
 -spec connect_cut(vertex_num(), vertex_num(), #we{}) ->
@@ -343,7 +343,7 @@ select_cut_edges_2({Type, Edge, VId, Face}=New, Stop, Es0, We, CEs) ->
 				   collect_cut_edge(Face, Es, EdgeId, E, Acc)
 			   end, [fail], Face, We),
     case {Type, CEs} of
-	{vertex, [{vertex, _, VId, _}|Acc]} -> %% Ignore alread connect VId
+	{vertex, [{vertex, _, VId, _}|Acc]} -> %% Ignore already connect VId
 	    select_cut_edges_2(hd(Next), Stop, Es, We, [New|Acc]);
 	_ ->
 	    select_cut_edges_2(hd(Next), Stop, Es, We, [New|CEs])

--- a/src/wings_view_win.erl
+++ b/src/wings_view_win.erl
@@ -285,7 +285,7 @@ create_hemilight(Panel, LightSz, SubFlags) ->
 
 create_cameralight(Panel, LightSz, SubFlags) ->
     CamLiLB = wxRadioButton:new(Panel, ?CAM_LIGHT, ?__(2, "Camera Light"), []),
-    Desc = ?__(3, "Camera light, emulates a physically based renderer, uses all material properities"),
+    Desc = ?__(3, "Camera light, emulates a physically based renderer, uses all material properties"),
     wxWindow:setToolTip(CamLiLB, wxToolTip:new(Desc)),
     CamLiSz = wxBoxSizer:new(?wxVERTICAL),
 
@@ -314,7 +314,7 @@ create_cameralight(Panel, LightSz, SubFlags) ->
 
 create_scenelight(Panel, LightSz, SubFlags) ->
     SceneLB = wxRadioButton:new(Panel, ?SCENE_LIGHT, ?__(10, "Scene Light"), []),
-    Desc = ?__(3, "Scene light, uses the scene lights, emulates a physically based renderer, uses all material properities"),
+    Desc = ?__(3, "Scene light, uses the scene lights, emulates a physically based renderer, uses all material properties"),
     wxWindow:setToolTip(SceneLB, wxToolTip:new(Desc)),
 
     SceneSz = wxBoxSizer:new(?wxVERTICAL),


### PR DESCRIPTION
Found via `codespell -q 3 -S *.lang,./OLD-NOTES -L ba,bord,fo,inout,ist,levl,lod,numer,ot`