### PR TITLE
Moved the material properties for plugins to another window

### DIFF
--- a/plugins_src/import_export/wpc_kerky.erl
+++ b/plugins_src/import_export/wpc_kerky.erl
@@ -11,7 +11,7 @@
 
 -module(wpc_kerky).
 
--export([init/0,menu/2,command/2,dialog/2]).
+-export([init/0,menu/2,command/2,has_dialog/1,dialog/2]).
 
 -include_lib("wings/e3d/e3d.hrl").
 -include_lib("wings/e3d/e3d_image.hrl").
@@ -171,6 +171,16 @@ command({edit,{plugin_preferences,?TAG}}, St) ->
     pref_dialog(St);
 command(_Spec, _St) ->
     next.
+
+%%% checking for Material / Light Dialogs support
+has_dialog(Kind) when is_atom(Kind) ->
+    Handled = [material_editor_setup, material_editor_result,
+               light_editor_setup, light_editor_result],
+    case lists:member(Kind,Handled) of
+        true -> {?__(1,"Kerkythea"),?TAG};
+        false -> false
+    end;
+has_dialog(_) -> false.
 
 %%% Material / Light Dialogs
 dialog({material_editor_setup, Name, Mat}, Dialog) ->

--- a/plugins_src/import_export/wpc_kerky.erl
+++ b/plugins_src/import_export/wpc_kerky.erl
@@ -174,11 +174,16 @@ command(_Spec, _St) ->
 
 %%% checking for Material / Light Dialogs support
 has_dialog(Kind) when is_atom(Kind) ->
-    Handled = [material_editor_setup, material_editor_result,
-               light_editor_setup, light_editor_result],
-    case lists:member(Kind,Handled) of
-        true -> {?__(1,"Kerkythea"),?TAG};
-        false -> false
+    case get_var(dialogs) of
+        false-> false;
+        _ ->
+            %% these are the dialogs handled by the plugin
+            Handled = [material_editor_setup, material_editor_result,
+                       light_editor_setup, light_editor_result],
+            case lists:member(Kind,Handled) of
+                true -> {?__(1,"Kerkythea"),?TAG};
+                false -> false
+            end
     end;
 has_dialog(_) -> false.
 

--- a/plugins_src/import_export/wpc_pov.erl
+++ b/plugins_src/import_export/wpc_pov.erl
@@ -211,11 +211,16 @@ command(_Spec, _St) ->
 
 %%% checking for Material / Light Dialogs support
 has_dialog(Kind) when is_atom(Kind) ->
-    Handled = [material_editor_setup, material_editor_result,
-               light_editor_setup, light_editor_result],
-    case lists:member(Kind,Handled) of
-        true -> {?__(1,"POV-Ray"),?TAG};
-        false -> false
+    case get_var(dialogs) of
+        false-> false;
+        _ ->
+            %% these are the dialogs handled by the plugin
+            Handled = [material_editor_setup, material_editor_result,
+                       light_editor_setup, light_editor_result],
+            case lists:member(Kind,Handled) of
+                true -> {?__(1,"POV-Ray"),?TAG};
+                false -> false
+            end
     end;
 has_dialog(_) -> false.
 

--- a/plugins_src/import_export/wpc_pov.erl
+++ b/plugins_src/import_export/wpc_pov.erl
@@ -14,7 +14,7 @@
 
 -module(wpc_pov).
 
--export([init/0, menu/2, command/2, dialog/2]).
+-export([init/0,menu/2,command/2,has_dialog/1,dialog/2]).
 
 -include_lib("wings/src/wings.hrl").
 -include_lib("wings/e3d/e3d.hrl").
@@ -208,6 +208,16 @@ command({edit, {plugin_preferences, ?TAG}}, St) ->
     pref_dialog(St);
 command(_Spec, _St) ->
     next.
+
+%%% checking for Material / Light Dialogs support
+has_dialog(Kind) when is_atom(Kind) ->
+    Handled = [material_editor_setup, material_editor_result,
+               light_editor_setup, light_editor_result],
+    case lists:member(Kind,Handled) of
+        true -> {?__(1,"POV-Ray"),?TAG};
+        false -> false
+    end;
+has_dialog(_) -> false.
 
 %%% Material / Light Dialogs
 dialog({material_editor_setup, Name, Mat}, Dialog) ->

--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -587,11 +587,16 @@ command(_Spec, _St) ->
 
 %%% checking for Material / Light Dialogs support
 has_dialog(Kind) when is_atom(Kind) ->
-    Handled = [material_editor_setup, material_editor_result,
-               light_editor_setup, light_editor_result],
-    case lists:member(Kind,Handled) of
-        true -> {?__(1,"YafaRay"),?TAG};
-        false -> false
+    case get_var(dialogs) of
+        false-> false;
+        _ ->
+            %% these are the dialogs handled by the plugin
+            Handled = [material_editor_setup, material_editor_result,
+                       light_editor_setup, light_editor_result],
+            case lists:member(Kind,Handled) of
+                true -> {?__(1,"YafaRay"),?TAG};
+                false -> false
+            end
     end;
 has_dialog(_) -> false.
 

--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -14,7 +14,7 @@
 %%
 
 -module(wpc_yafaray).
--export([init/0,menu/2,dialog/2,command/2]).
+-export([init/0,menu/2,dialog/2,has_dialog/1,command/2]).
 
 %% Debug exports
 %% -export([now_diff_1/1]).
@@ -584,6 +584,16 @@ command({edit,{plugin_preferences,?TAG}}, St) ->
 command(_Spec, _St) ->
     %% erlang:display({?MODULE,?LINE,_Spec}),
     next.
+
+%%% checking for Material / Light Dialogs support
+has_dialog(Kind) when is_atom(Kind) ->
+    Handled = [material_editor_setup, material_editor_result,
+               light_editor_setup, light_editor_result],
+    case lists:member(Kind,Handled) of
+        true -> {?__(1,"YafaRay"),?TAG};
+        false -> false
+    end;
+has_dialog(_) -> false.
 
 dialog({material_editor_setup,Name,Mat}, Dialog) ->
     case is_plugin_active(edit) of

--- a/src/wings_material.erl
+++ b/src/wings_material.erl
@@ -735,8 +735,8 @@ edit_dialog(Name, Assign, St=#st{mat=Mtab0}, Mat0, DrawSphere) ->
             {value, Mat0, [{key,material}]}], [{proportion, 1},{title," Wings 3D "}]},
     %% Check for plugin's material editor available and inset their information
     %% in a dropdown list to allow users to choose their properties via a new dialog
-    Qs2 = plugin_dlg_menu(Name, Qs1, wings_plugin:has_dialog(material_editor_setup)),
-    Qs = {vframe_dialog, [{vframe, Qs2}], [{buttons, [ok, cancel]}, {key, result}]},
+    Qs2 = plugin_dlg_menu(Name, wings_plugin:has_dialog(material_editor_setup)),
+    Qs = {vframe_dialog, [Qs1 | Qs2], [{buttons, [ok, cancel]}, {key, result}]},
     Ask = fun([{diffuse,Diff},
                {metallic, Met},
                {roughness, Roug},
@@ -790,13 +790,12 @@ plugin_dlg_hook(Name) ->
             end
         end}.
 
-plugin_dlg_menu(_, Qs, []) -> Qs;
-plugin_dlg_menu(Name, Qs, Plugins) ->
+plugin_dlg_menu(_, []) -> [];
+plugin_dlg_menu(Name, Plugins) ->
     [{_,PlgId}|_] = Opts = [{?__(1,"Select..."),{none,none}}]++[{PlgName,{Pm,Tag}} || {Pm,{PlgName,Tag}} <- lists:sort(Plugins)],
     DefPlg = wings_pref:get_value(material_default_plugin,PlgId),
     Hook = plugin_dlg_hook(Name),
-    [Qs,
-     {hframe, [
+    [{hframe, [
          {label_column,
           [{?__(2,"Available"), {menu, Opts, DefPlg, [{key,plugin},Hook]}}]},
          {button, ?__(3,"Edit Property..."),show_plugin_dlg,[{key,show_plugin_dlg},Hook]}


### PR DESCRIPTION
The change was made to speed up the access to the Material dialog which
became too slow since the UI was migrated to use wx library.
When an user choose a render plugin to change its setting that will be
assumed as his/her preferred render engine (which usually is). So, in the
next time the material dialog be accessed it will automatically set to
use that one.

p.s.: I tried to minimise the changes and keep the material data consistent with
any Wings3D version.

NOTE: The material properties for plugins are now accessed by choosing the
plugin name in a drop-down list and clicking on the "Edit..." button.