### PR TITLE
Fixed a script error when building 32bits version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ $(SUBDIRS):
 #
 .PHONY: win32
 win32: opt lang
+	rm -f priv/libigl.*
 	(cd win32; $(MAKE))
 	escript tools/release
 


### PR DESCRIPTION
The 'libigl' doesn't generate code for 32bits. So, when building a win32 version
the igl files must not be present in the 'priv' folder to avoid a script error.