### PR TITLE
Fixed marquee transparency on Linux

### DIFF
--- a/src/wings_frame.erl
+++ b/src/wings_frame.erl
@@ -730,7 +730,7 @@ make_overlay(Parent) ->
 	?wxNO_BORDER,
     Overlay = wxFrame:new(),
     case {os:type(), {?wxMAJOR_VERSION, ?wxMINOR_VERSION}} of
-        {{_, linux}, Ver} when Ver > {3,0} ->
+        {{_, linux}, Ver} when Ver >= {3,0} ->
             wxFrame:setBackgroundStyle(Overlay, 3); %% ?wxBG_STYLE_TRANSPARENT
         _ -> ok
     end,

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -306,7 +306,7 @@ make_overlay(Parent, ScreenPos) ->
     OL = wxFrame:new(),
     Flags = ?wxFRAME_TOOL_WINDOW bor ?wxFRAME_FLOAT_ON_PARENT bor ?wxFRAME_NO_TASKBAR,
     TCol = case {os:type(), {?wxMAJOR_VERSION, ?wxMINOR_VERSION}} of
-               {{_, linux}, Ver} when Ver > {3,0} ->
+               {{_, linux}, Ver} when Ver >= {3,0} ->
                    wxFrame:setBackgroundStyle(OL, 3), %% ?wxBG_STYLE_TRANSPARENT
                    0;
                {{_, darwin}, _} ->


### PR DESCRIPTION
NOTE: Fixed marquee transparency on Linux. Thanks to Klim.

![Screenshot from 2022-02-19 14-27-38](https://user-images.githubusercontent.com/365243/154812049-2a619830-501f-4b34-b2ac-8a4ccf5c8336.png)

