### PR TITLE
Fix various typos

### DIFF
--- a/README-22.txt
+++ b/README-22.txt
@@ -46,7 +46,7 @@ New stuff
 
 - Added a dialog to STL exporter allowing users to set the scale.
   Thanks to dawntreader, imagine and Mert HANCIOGLU(instagram) for provide
-  us informations about the slicers measures. [Micheus]
+  us information about the slicers measures. [Micheus]
 
 - Added new primitive screw thread [Micheus]
 
@@ -156,8 +156,8 @@ Bugs fixed
 - Fixed importing non-square 'dds' textures with mipmaps
   which caused an eternal loop. Thanks Simon Griffiths. [dgud]
 
-- Fixed crash when trying to edit area ligth properties
-  and not selecting an area ligth. Thanks Lars Thorsen. [dgud]
+- Fixed crash when trying to edit area light properties
+  and not selecting an area light. Thanks Lars Thorsen. [dgud]
 
 - Fix ttf text plugin error handling. Thanks Hank. [dgud]
 

--- a/c_src/tess/README
+++ b/c_src/tess/README
@@ -208,7 +208,7 @@ The interface
 	  GLU_TESS_WINDING_NEGATIVE
 	  GLU_TESS_WINDING_ABS_GEQ_TWO
 
-      The input contours parition the plane into regions.  A winding
+      The input contours partition the plane into regions.  A winding
       rule determines which of these regions are inside the polygon.
       
       For a single contour C, the winding number of a point x is simply

--- a/c_src/tess/sweep.c
+++ b/c_src/tess/sweep.c
@@ -437,7 +437,7 @@ static void CallCombine( GLUtesselator *tess, GLUvertex *isect,
 static void SpliceMergeVertices( GLUtesselator *tess, GLUhalfEdge *e1,
 				 GLUhalfEdge *e2 )
 /*
- * Two vertices with idential coordinates are combined into one.
+ * Two vertices with identical coordinates are combined into one.
  * e1->Org is kept, while e2->Org is discarded.
  */
 {
@@ -940,7 +940,7 @@ static void ConnectRightVertex( GLUtesselator *tess, ActiveRegion *regUp,
 static void ConnectLeftDegenerate( GLUtesselator *tess,
 				   ActiveRegion *regUp, GLUvertex *vEvent )
 /*
- * The event vertex lies exacty on an already-processed edge or vertex.
+ * The event vertex lies exactly on an already-processed edge or vertex.
  * Adding the new vertex involves splicing it into the already-processed
  * part of the mesh.
  */

--- a/e3d/e3d_mat.erl
+++ b/e3d/e3d_mat.erl
@@ -33,7 +33,7 @@
        float(),float(),float(),
        float(),float(),float()}.
 
-%% General 4x4 matrix represention.
+%% General 4x4 matrix representation.
 -type matrix() :: 'identity' | compact_matrix() |
   {float(),float(),float(),float(),
    float(),float(),float(),float(),

--- a/plugins_src/autouv/auv_mapping.erl
+++ b/plugins_src/autouv/auv_mapping.erl
@@ -579,7 +579,7 @@ lsq_setup(Fs,We,Pinned) ->
     {Mfp1c,Mfp2c,Mfp2nc,LuLv} = build_cols(M1,M2,M2n,Lquv),
     ?DBG("lsq_int - LuLv = ~p~n", [LuLv]),
     %% Compose the matrix and vector to solve
-    %% for a Least SQares solution.
+    %% for a Least Squares solution.
     {Af,Ap} = build_matrixes(N,Mfp1c,Mfp2c,Mfp2nc),
     ?DBG("Solving matrices~n", []),
     X0Fix = auv_matrix:vector(lists:duplicate(M-Np, Usum/Np)++

--- a/plugins_src/autouv/shaders/camouflage.fs
+++ b/plugins_src/autouv/shaders/camouflage.fs
@@ -61,7 +61,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
   vec3 posn = normalize(pos);
   float ca = cos(-a);  // alpha
   float cb = cos(b);  // beta
-  float cy = cos(-y); // gama | [-] from left to righ hand
+  float cy = cos(-y); // gama | [-] from left to right hand
   float sa = sin(-a);
   float sb = sin(b);
   float sy = sin(-y);

--- a/plugins_src/autouv/shaders/caustics.fs
+++ b/plugins_src/autouv/shaders/caustics.fs
@@ -36,7 +36,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
   vec3 posn = normalize(pos);
   float ca = cos(-a);  // alpha
   float cb = cos(b);  // beta
-  float cy = cos(-y); // gama | [-] from left to righ hand
+  float cy = cos(-y); // gama | [-] from left to right hand
   float sa = sin(-a);
   float sb = sin(b);
   float sy = sin(-y);

--- a/plugins_src/autouv/shaders/lava.fs
+++ b/plugins_src/autouv/shaders/lava.fs
@@ -32,7 +32,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
   vec3 posn = normalize(pos);
   float ca = cos(-a);  // alpha
   float cb = cos(b);  // beta
-  float cy = cos(-y); // gama | [-] from left to righ hand
+  float cy = cos(-y); // gama | [-] from left to right hand
   float sa = sin(-a);
   float sb = sin(b);
   float sy = sin(-y);

--- a/plugins_src/autouv/shaders/marble.fs
+++ b/plugins_src/autouv/shaders/marble.fs
@@ -123,7 +123,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
     vec3 posn = normalize(pos);
     float ca = cos(-a);  // alpha
     float cb = cos(b);  // beta
-    float cy = cos(-y); // gama | [-] from left to righ hand
+    float cy = cos(-y); // gama | [-] from left to right hand
     float sa = sin(-a);
     float sb = sin(b);
     float sy = sin(-y);

--- a/plugins_src/autouv/shaders/noise_ext.fs
+++ b/plugins_src/autouv/shaders/noise_ext.fs
@@ -348,7 +348,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
     vec3 posn = normalize(pos);
     float ca = cos(-a);  // alpha
     float cb = cos(b);  // beta
-    float cy = cos(-y); // gama | [-] from left to righ hand
+    float cy = cos(-y); // gama | [-] from left to right hand
     float sa = sin(-a);
     float sb = sin(b);
     float sy = sin(-y);

--- a/plugins_src/autouv/shaders/voronoi.fs
+++ b/plugins_src/autouv/shaders/voronoi.fs
@@ -34,7 +34,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
     vec3 posn = normalize(pos);
     float ca = cos(-a);  // alpha
     float cb = cos(b);  // beta
-    float cy = cos(-y); // gama | [-] from left to righ hand
+    float cy = cos(-y); // gama | [-] from left to right hand
     float sa = sin(-a);
     float sb = sin(b);
     float sy = sin(-y);

--- a/plugins_src/autouv/shaders/wood.fs
+++ b/plugins_src/autouv/shaders/wood.fs
@@ -235,7 +235,7 @@ vec3 rotate(vec3 pos, float a, float b, float y) {
   vec3 posn = normalize(pos);
   float ca = cos(-a);  // alpha
   float cb = cos(b);  // beta
-  float cy = cos(-y); // gama | [-] from left to righ hand
+  float cy = cos(-y); // gama | [-] from left to right hand
   float sa = sin(-a);
   float sb = sin(b);
   float sy = sin(-y);

--- a/plugins_src/primitives/wpc_plane.erl
+++ b/plugins_src/primitives/wpc_plane.erl
@@ -104,7 +104,7 @@ make_plane([{_,Nres},{_,Size},{_,Thickness},{_,sombrero},
     {new_shape,"Sombrero Plane",Fs,Vs}.
 
 %%%
-%%% Vertex distrobutions
+%%% Vertex distributions
 %%%
 
 regular_plane_verts(Nres, Size, Thickness) ->

--- a/shaders/background.vs
+++ b/shaders/background.vs
@@ -1,5 +1,5 @@
 //
-// Vertex shader for most of the frament shader
+// Vertex shader for most of the fragment shader
 //
 #version 120
 

--- a/shaders/standard.vs
+++ b/shaders/standard.vs
@@ -1,5 +1,5 @@
 //
-// Vertex shader for most of the frament shader
+// Vertex shader for most of the fragment shader
 //
 #version 120
 

--- a/src/wings_bool.erl
+++ b/src/wings_bool.erl
@@ -196,7 +196,7 @@ merge_1(#{we:=We10,el:=_EL10,temp_es:=TEs1}=I10,
     Loops0 = build_vtx_loops(EdgeInfo), %% Figure out edge loops
     L10 = [split_loop(Loop, Vmap, {We10,We20}) || Loop <- Loops0], % Split loops per We and precalc
     L20 = [split_loop(Loop, Vmap, {We20,We10}) || Loop <- Loops0], % some data
-    %% Remove vertexes on triangulated edges
+    %% Remove vertices on triangulated edges
     Loops1 = [filter_tess_edges(Loop,We10,We20) || Loop <- lists:zip(L10,L20)],
     Loops = sort_largest(Loops1, Vmap),
     %% Create vertices on the edge-loops

--- a/src/wings_dissolve.erl
+++ b/src/wings_dissolve.erl
@@ -226,7 +226,7 @@ succ([], [Succ|_]) -> Succ.
 %%  Return 'error' if the faces in FaceSet does not form a
 %%  simple region without holes.
 %%
-%%  Equvivalent to
+%%  Equivalent to
 %%      case outer_edge_partition(FaceSet,WingedEdge) of
 %%         [Loop] -> Loop;
 %%         [_|_] -> error

--- a/src/wings_face_cmd.erl
+++ b/src/wings_face_cmd.erl
@@ -45,7 +45,7 @@ menu(X, Y, St) ->
 	    {?__(12,"Bridge"),bridge_fun(),
 	     {?__(13,"Create a bridge or tunnel between two faces") ++
 	      ?__(40," or face regions"),[],
-	      ?__(43,"Create a bridge or tunnel from reference vertexes")},[]},
+	      ?__(43,"Create a bridge or tunnel from reference vertices")},[]},
 	    separator,
 	    {?__(14,"Bump"),bump,
 	     ?__(15,"Create bump of selected faces")},

--- a/src/wings_glu_tess.erl
+++ b/src/wings_glu_tess.erl
@@ -38,7 +38,7 @@ init() ->
 
 %% @doc General purpose polygon triangulation.
 %% The first argument is the normal and the second a list of
-%% vertex positions. Returned is a list of indecies of the vertices
+%% vertex positions. Returned is a list of indices of the vertices
 %% and a binary (64bit native float) containing an array of
 %% vertex positions, it starts with the vertices in Vs and
 %% may contain newly created vertices in the end.

--- a/src/wings_light.erl
+++ b/src/wings_light.erl
@@ -871,14 +871,14 @@ scene_lights_fun(#dlo{drag=Drag,src_we=We0}=D) ->
     We = case We0 of
 	     #we{light=#light{type=area}} ->
 		 %% For an area light it looks better in vertex/edge/face
-		 %% modes to emulate with the static non-splitted shape
+		 %% modes to emulate with the static non-split shape
 		 %% during drag. It would be more correct if the area light
 		 %% updating would use the resulting #we{}, but it does not
 		 %% exist until the drag is done.
 		 wings_draw:original_we(D);
 	     _ ->
 		 %% Non-area lights drag the whole shape so they can use
-		 %% the dynamic part of the splitted shape
+		 %% the dynamic part of the split shape
 		 %% (which is the whole shape).
 		 We0
 	 end,

--- a/src/wings_sel_cmd.erl
+++ b/src/wings_sel_cmd.erl
@@ -544,7 +544,7 @@ select_group({Mode,_}=Key, #st{ssels=Ssels}=St) ->
     St#st{selmode=Mode,sel=ValidSel}.
 
 %%%% Delete Groups that return an empty selection. Invalid ssels can result from
-%%%% creating or deleting geomerty.
+%%%% creating or deleting geometry.
 delete_invalid_groups(#st{ssels=Ssels}=St0) ->
     case gb_trees:is_empty(Ssels) of
       true ->

--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -590,7 +590,7 @@ handle_magnet_event(Ev,T) ->
 
 
 %%%
-%%% Handeler for In-Drag Magnet Radius Adjustments
+%%% Handler for In-Drag Magnet Radius Adjustments
 %%%
 
 tweak_drag_mag_adjust(#tweak{st=#st{selmode=body}}) -> keep;

--- a/src/wings_u.erl
+++ b/src/wings_u.erl
@@ -187,7 +187,7 @@ get_rel_path(_,Src) -> Src.   % paths are in a different Drive - ignore routine
 get_rel_path([]=_Dst, []=_Src, Acc) -> Acc;     % export and file dir are the same
 get_rel_path([_|T], [], Acc) ->             % file is in some dir level in the Dst
     get_rel_path(T,[],["../"]++Acc);
-get_rel_path([], [H|T], Acc)->              % all previous dir match - file is in uppper dir level
+get_rel_path([], [H|T], Acc)->              % all previous dir match - file is in upper dir level
     get_rel_path([],T,[H]++Acc);
 get_rel_path([H|T0], [H|T1], Acc) ->        % continue checking in next dir level
     get_rel_path(T0,T1,Acc);

--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -615,7 +615,7 @@ translation_string(outliner)         -> ?__(137,"Outliner");
 translation_string(object)           -> ?__(138,"Geometry Graph");
 translation_string(palette)          -> ?__(139,"Palette");
 translation_string(console)          -> ?__(140,"Console");
-translation_string(geom_viewer)      -> ?__(141,"New Geomerty Window");
+translation_string(geom_viewer)      -> ?__(141,"New Geometry Window");
 translation_string(uv_editor_window) -> ?__(142,"UV Editor Window");
 
 %%%% Help Menu


### PR DESCRIPTION
Found via `codespell -q 3 -S *.lang,./OLD-NOTES -L accout,anyother,atleast,ba,bord,clen,currentry,dota,enew,fo,havew,inh,inout,ist,levl,lod,neares,noes,numer,ons,ot,rmove,ro,tesselate,tesselated,tesselation,tesselator`