### PR TITLE
Added option to rotate the environment map

### DIFF
--- a/shaders/background.fs
+++ b/shaders/background.fs
@@ -21,6 +21,7 @@ void main(void)
 {
   vec3 view_vec = normalize(-position);
   vec2 index = vec2uv(view_vec);
+  index = vec2(index.x+bg_rotate, index.y);
   float scale = 3.0;  // ~ sqrt(NoOfmipmaps)  mipmaps = 10 for 2048x1024
   float lod = pow((0.1+bg_blur) * scale, 2.0);
 

--- a/shaders/lib_envlight.glsl
+++ b/shaders/lib_envlight.glsl
@@ -14,6 +14,7 @@
 uniform sampler2D EnvBrdfMap;
 uniform sampler2D EnvDiffMap;
 uniform sampler2D EnvSpecMap;
+uniform float bg_rotate;
 
 vec2 vec2uv(vec3 vec)
 {
@@ -31,6 +32,7 @@ vec3 background_lighting(PBRInfo pbrInputs, vec3 N, vec3 reflection)
 {
     vec3 refl = normalize(reflection);
     vec2 index = vec2uv(refl);
+    index = vec2(index.x+bg_rotate, index.y);
 
     vec2 brdf = texture2D(EnvBrdfMap, vec2(pbrInputs.NdotV, pbrInputs.perceptualRoughness)).rg;
     vec3 difflight = SRGBtoLINEAR(texture2D(EnvDiffMap, index)).rgb;

--- a/src/wings_light.erl
+++ b/src/wings_light.erl
@@ -58,6 +58,7 @@ def_envmap() ->
 init() ->
     wings_pref:set_default(show_bg, false),
     wings_pref:set_default(show_bg_blur, 0.5),
+    wings_pref:set_default(show_bg_rotate, 0.0),
     wings_pref:set_default(bg_image, def_envmap()),
     EnvImgRec = load_env_file(wings_pref:get_value(bg_image)),
     init(false, EnvImgRec).

--- a/src/wings_shaders.erl
+++ b/src/wings_shaders.erl
@@ -78,21 +78,22 @@ use_prog(Name, RS) ->
             RS0 = set_uloc('Exposure', wings_pref:get_value(cam_exposure), RS#{shader=>Shader}),
             RS1 = set_uloc(ws_matrix, e3d_mat:identity(), RS0),
             RS2 = set_uloc(ws_eyepoint, maps:get(ws_eyepoint, RS1, undefined), RS1),
+            RS3 = wings_shaders:set_uloc(bg_rotate, wings_pref:get_value(show_bg_rotate), RS2),
 
             case Name of
                 1 ->
-                    WorldFromView = e3d_transform:inv_matrix(maps:get(view_from_world, RS2)),
+                    WorldFromView = e3d_transform:inv_matrix(maps:get(view_from_world, RS3)),
                     LPos = e3d_mat:mul_point(WorldFromView, wings_pref:get_value(cl_lightpos)),
-                    RS3 = set_uloc('ws_lightpos', LPos, RS2),
-                    set_uloc('LightColor', linear(cl_lightcol), RS3);
+                    RS4 = set_uloc('ws_lightpos', LPos, RS3),
+                    set_uloc('LightColor', linear(cl_lightcol), RS4);
                 2 ->
-                    WorldFromView = e3d_transform:inv_matrix(maps:get(view_from_world, RS2)),
+                    WorldFromView = e3d_transform:inv_matrix(maps:get(view_from_world, RS3)),
                     LPos = e3d_mat:mul_point(WorldFromView, ?hl_lightpos),
-                    RS3 = set_uloc('ws_lightpos', LPos, RS2),
-                    RS4 = set_uloc('SkyColor', linear(hl_skycol), RS3),
-                    set_uloc('GroundColor', linear(hl_groundcol), RS4);
+                    RS4 = set_uloc('ws_lightpos', LPos, RS3),
+                    RS5 = set_uloc('SkyColor', linear(hl_skycol), RS4),
+                    set_uloc('GroundColor', linear(hl_groundcol), RS5);
                 _ ->
-                    RS2
+                    RS3
             end;
         Shaders ->
             error({shader_not_found, Name, maps:keys(Shaders)})


### PR DESCRIPTION
It's a missing option (in my opinion) since mostly 3D apps which works with
PBR visualisation allow us to rotate the environment map around the static
object to give us the possibility to evaluate how the object is lit by
different angles.

NOTE: Added option to rotate the environment map.