### PR TITLE
Fixed a soft crash when using Connect RMB (Absolute option)

### DIFF
--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -440,6 +440,8 @@ slide_mode(MinUp,MinDw) ->
     end.
 
 slide_units({absolute,_,false},_,_) -> [distance];
+slide_units({absolute,_Freeze,true},unknown,unknown) ->
+    [{distance, {-1.0, 1.0}}];
 slide_units({absolute,_Freeze,true},MinUp,MinDw) ->
     [{distance, {-MinUp, MinDw}}];
 slide_units({relative,_,false},_,_) -> [percent];


### PR DESCRIPTION
I noticed a soft crash when I selected only one edge in the entire scene and
choose the Connect command [RMB] switching from Percent to the Absolute [1]
option.

In that situation the MinUp and MinDown in Units parameter for wings_drag have
the 'unknown' value.

```
Long stack trace:
[{erlang,'-',[unknown],[{error_info,#{module => erl_erts_errors}}]},
 {wings_edge_cmd,slide_units,3,[{file,"wings_edge_cmd.erl"},{line,444}]},
 {wings_edge_cmd,slide,1,[{file,"wings_edge_cmd.erl"},{line,409}]},
 {wings_develop,time_command,2,[{file,"wings_develop.erl"},{line,87}]},
 {wings,raw_command,4,[{file,"wings.erl"},{line,643}]},
 {wings_wm,handle_event,3,[{file,"wings_wm.erl"},{line,1039}]},
 {wings_wm,send_event,2,[{file,"wings_wm.erl"},{line,1005}]},
 {wings_wm,do_dispatch,2,[{file,"wings_wm.erl"},{line,897}]},
 {wings_wm,dispatch_event,1,[{file,"wings_wm.erl"},{line,806}]},
 {wings_wm,get_and_dispatch,0,[{file,"wings_wm.erl"},{line,692}]},
 {wings,init_part2,3,[{file,"wings.erl"},{line,108}]},
 {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]
```