### PR TITLE
Hotkey handle can cause Wings3D crash in a multiple display setup

### DIFF
--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -579,7 +579,8 @@ screen2local(Pos) ->
     wxWindow:screenToClient(this_win(), Pos).
 
 local_mouse_state() ->
-    {B,X0,Y0} = wings_io:get_mouse_state(),
+    {B,_,_} = wings_io:get_mouse_state(),
+    {X0,Y0} = wx_misc:getMousePosition(),   %% temporary - until wx_misc:getMouseState be fixed
     {X,Y} = screen2local({X0, Y0}),
     {B,X,Y}.
 


### PR DESCRIPTION
NOTE:
In a multiple display setup Wings3D crashes if a hotkey is pressed if its window is not in the main display. Thanks Nova