### PR TITLE
Fixed an issue that was masking real error messages for a while

### DIFF
--- a/src/wings_dialog.erl
+++ b/src/wings_dialog.erl
@@ -884,7 +884,10 @@ build_dialog(AskType, Title, Qs) ->
 			     {Dialog, DialogData}
 		     catch Class:Reason:ST ->
 			     %% Try to clean up
-			     reset_dialog_parent(Dialog),
+			     case ?GET(dialog_parent) of
+			         [] -> ignore;
+			         _ -> reset_dialog_parent(Dialog)
+			     end,
 			     wxDialog:destroy(Dialog),
 			     erlang:raise(Class, Reason, ST)
 		     end


### PR DESCRIPTION
I've already noticed that before, but always forget about to check from where it was coming. When a crash was happening in a dialog call the catch process sometimes was trying to pop an unexistent pararent window from the stack. That was causing another crash which the message was shown on the console:

```
Reason: {{badmatch,[]},
         [{wings_dialog,reset_dialog_parent,1,
                        [{file,"wings_dialog.erl"},{line,435}]},
          {wings_dialog,'-build_dialog/3-fun-0-',3,
                        [{file,"wings_dialog.erl"},{line,887}]},
          {wx,batch,1,[{file,"wx.erl"},{line,201}]},
          {wings_dialog,dialog_1,5,[{file,"wings_dialog.erl"},{line,267}]},
          {wings_wm,handle_event,3,[{file,"wings_wm.erl"},{line,1039}]},
          {wings_wm,send_event,2,[{file,"wings_wm.erl"},{line,1006}]},
          {wings_wm,do_dispatch,2,[{file,"wings_wm.erl"},{line,898}]},
          {wings_wm,dispatch_event,1,[{file,"wings_wm.erl"},{line,807}]},
          {wings_wm,get_and_dispatch,0,[{file,"wings_wm.erl"},{line,693}]},
          {wings,init_part2,3,[{file,[...]},{line,...}]},
          {proc_lib,init_p_do_apply,3,[{file,...},{...}]}]}
```

Avoiding that process allow us to get the real cause of the original crash.