### PR TITLE
Changed the label used to represent the sphere radius

### DIFF
--- a/src/wings_jp.lang
+++ b/src/wings_jp.lang
@@ -4051,9 +4051,9 @@
     {1,"経線分割数"},
     % "Slices"
     {2,"横分割数"},
-    % "X Radial"
+    % "X Radius"
     {3,"半径(X方向)"},
-    % "Y Radial"
+    % "Y Radius"
     {4,"半径(Y方向)"}
    ]},
   {tetrahedron,

--- a/src/wings_shapes.erl
+++ b/src/wings_shapes.erl
@@ -300,8 +300,8 @@ sphere(Ask, St) when is_atom(Ask) ->
     Q = [{label_column, [
 	    {?STR(sphere,1,"Sections"), {text,16,[{range,{3,infinity}}]}},
 	    {?STR(sphere,2,"Slices"), {text,8,[{range,{3,infinity}}]}},
-	    {?STR(sphere,3,"X Radial"), {text,2.0,[{range,{0.0,infinity}}]}},
-	    {?STR(sphere,4,"Y Radial"), {text,2.0,[{range,{0.0,infinity}}]}}
+	    {?STR(sphere,3,"X Radius"), {text,2.0,[{range,{0.0,infinity}}]}},
+	    {?STR(sphere,4,"Y Radius"), {text,2.0,[{range,{0.0,infinity}}]}}
     	 ]},
 	 transform_obj_dlg()],
     ask(sphere, Ask, Q, St);


### PR DESCRIPTION
The changed was suggested by an user and I think it's a correct observation.

NOTE: Replaced the label 'Radial' by 'Radius' in Sphere primitive dialog. Thanks to e.m.hobo for the suggestion.