### PR TITLE
Fixed a bug in internal screenshot naming

### DIFF
--- a/src/wings_image.erl
+++ b/src/wings_image.erl
@@ -173,7 +173,7 @@ screenshot([SaveView,Name], St) ->
       true -> wings_view:command({views,{save,[Name]}},St);
       false -> St
     end;
-screenshot(Name, St) ->
+screenshot([Name], St) ->
     viewport_screenshot(Name),
     St.
 


### PR DESCRIPTION
The screenshot name was get into a list which was causing the wings_dialog to brach when building the text control.

NOTE: Fixed a crach when renaming screenshots. Thanks to markie.