### PR TITLE
Fixed a crash when a context menu is active and we close its parent window

### DIFF
--- a/src/wings_wm.erl
+++ b/src/wings_wm.erl
@@ -238,7 +238,9 @@ new_resolve_z(Z) when is_integer(Z), Z >= 0-> Z.
 delete(Name) ->
     case wxwindow(Name) of
         undefined -> ignore;
-        Win -> wings_frame:close(Win)
+        Win ->
+            timer:sleep(200),
+            wings_frame:close(Win)
     end,
     Windows = delete_windows(Name, get(wm_windows)),
     put(wm_windows, Windows),


### PR DESCRIPTION
This error was noticed in the AutoUV Segmentation window when the context menu was active and the use clicked in the [X] to close its parent window. Ref.: http://www.wings3d.com/forum/showthread.php?tid=3093

NOTE: Fixed the cause of the crash when closing AutoUV Segmentation window with the context menu active. Thanks to markie.