### PR TITLE
Fix and workaround related to mouse coordinate in multiple display setup

### DIFF
--- a/src/wings_io_wx.erl
+++ b/src/wings_io_wx.erl
@@ -147,8 +147,9 @@ set_cursor(CursorId) ->
 
 get_mouse_state() ->
     wx:batch(fun() ->
+             {X,Y} = wx_misc:getMousePosition(),  %% Temporary to fix coordinate em multiple displays
 		     MS = wx_misc:getMouseState(),
-		     #wxMouseState{x=X, y=Y,  %% integer()
+		     #wxMouseState{%% x=X, y=Y,  %% integer()
 				   leftDown=Left,
 				   middleDown=Middle,
 				   rightDown=Right %% bool()

--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -474,8 +474,7 @@ popup_event_handler({click, Id, Click, Ns}, {Parent,Owner}, Entries0) ->
             wings_wm:release_focus(),
             delete;
 	{submenu, Names, Menus, MagnetClick} ->
-	    {_, X,Y} = wings_io:get_mouse_state(),
-	    Entries = wx_popup_menu(Parent, {X,Y}, Names, Menus, MagnetClick, dialog_blanket),
+	    Entries = wx_popup_menu(Parent, wx_misc:getMousePosition(), Names, Menus, MagnetClick, dialog_blanket),
 	    {replace, fun(Ev) -> popup_event_handler(Ev, {Parent,Owner}, Entries) end}
     end;
 popup_event_handler(redraw,_,_) ->


### PR DESCRIPTION
As an advice for us, we should preferer to use wx_misc:getMousePosition() if we need only the mouse coordinates 
instead of wings_io:get_mouse_state() to get the mouse coordinates.