### PR TITLE
Disabling MSAA feature in case of hard crash on Wings3D start

### DIFF
--- a/src/wings_gl.erl
+++ b/src/wings_gl.erl
@@ -65,25 +65,18 @@ check_for_msaa() ->
     not MSAA andalso io:format("Multisampling (MSAA) not available~n").
 
 attributes() ->
-    MSAA = wings_pref:get_value(gl_msaa, true),
-    SB = case os:type() of
-             {unix, Os} when Os =/= darwin ->
-                 %% Sample buffers does not currently work on Wayland
-                 case os:getenv("XDG_SESSION_TYPE") of
-                     "x11" -> [?WX_GL_SAMPLE_BUFFERS,1, ?WX_GL_SAMPLES,4];
-                     "X11" -> [?WX_GL_SAMPLE_BUFFERS,1, ?WX_GL_SAMPLES,4];
-                     _ -> []
-                 end;
-             _ ->
-                 [?WX_GL_SAMPLE_BUFFERS,1, ?WX_GL_SAMPLES,4]
-         end,
+    %% init Sample buffers attributes if multisampling available
+    SB =
+        case wings_pref:get_value(gl_msaa, true) of
+            true -> [?WX_GL_SAMPLE_BUFFERS,1, ?WX_GL_SAMPLES,4, 0];
+            false -> [0]
+        end,
     {attribList,
      [?WX_GL_RGBA,
       ?WX_GL_MIN_RED,8,?WX_GL_MIN_GREEN,8,?WX_GL_MIN_BLUE,8,
       ?WX_GL_DEPTH_SIZE, 24,
       ?WX_GL_DOUBLEBUFFER
-     ] ++
-         if MSAA -> SB ++ [0]; true -> [0] end
+     ] ++ SB
     }.
 
 window(Parent, Context0, Connect, Show) ->

--- a/src/wings_gl.erl
+++ b/src/wings_gl.erl
@@ -45,12 +45,40 @@
 -define(WX_GL_SAMPLES,18).         %% 4 for 2x2 antialiasing supersampling on most graphics cards
 -endif.
 
+%%
+%% A call to is_msaa_available(true) must be followed by a call to working()
+%% just after the OpenGL window be created
+%%
 init(Parent) ->
+    is_msaa_available(true),
     GL = window(Parent, undefined, true, false),
+    working(),
     init_extensions(),
     GL.
 
+%%% Intel GPUs have been crashing Wings3D on start. It's related to MSAA has
+%%% been turned off on Intel Control Panel.
+%%% To avoid that we cannot initialize GLCanvas with MSAA in case it fail.
+is_msaa_available(Write) ->
+    case file:read_file_info(temp_file()) of
+        {ok, _} ->
+            wings_pref:set_value(gl_msaa, false),
+            io:format("Multisampling (MSAA) not available~n",[]);
+        {error,_} ->
+            wings_pref:set_value(gl_msaa, true)
+    end,
+    Write andalso file:write_file(temp_file(), <<"Delete me if MSAA is working">>).
+
+%% Call me if OpenGL initiation with MSAA enabled worked as expected
+working() ->
+    _ = wings_pref:get_value(gl_msaa) andalso file:delete(temp_file()),
+    ok.
+
+temp_file() ->
+    filename:join(wings_u:basedir(user_cache), "mass_tmp.txt").
+
 attributes() ->
+    MSAA = wings_pref:get_value(gl_msaa, true),
     SB = case os:type() of
              {unix, Os} when Os =/= darwin ->
                  %% Sample buffers does not currently work on Wayland
@@ -68,7 +96,7 @@ attributes() ->
       ?WX_GL_DEPTH_SIZE, 24,
       ?WX_GL_DOUBLEBUFFER
      ] ++
-         SB ++ [0]
+         if MSAA -> SB ++ [0]; true -> [0] end
     }.
 
 window(Parent, Context0, Connect, Show) ->


### PR DESCRIPTION
That is not clear if it's a GPU driver or wxWidgets issue. After a couple of tests playing around with the 'Intel Graphics Control Panel' settings I found out the issue was caused by the MSAA setting. By switching it from 'Turn Off' to 'Use Application Settings' fixed the problem.

Because it seems MSAA is turned off by default in some systems and because it's hard to the user to figure out it's causing the Wings3D failing to start, I'm proposing a validation. Since now we have a way to check if wxGLCanvas can support some attribute (in Erlang 25.3) we can  test for it before create a wxGLContext and eventually start Wings3D with MSAA feature disabled.

NOTE: This fix a hard crash on starting Wings3D related to MSAA disabled in a PC setup which the main GPU is an Intel.