### PR TITLE
Fixed an issue to Connect RMB option when only one edge was selected

### DIFF
--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -381,6 +381,7 @@ hardness(hard, St) ->
 %%% The Slide command.
 %%%
 
+slide(#st{sel=[]}=St) -> St;
 slide(St0) ->
     Mode = wings_pref:get_value(slide_mode, relative),
     Stop = wings_pref:get_value(slide_stop, false),


### PR DESCRIPTION
It was noticed if we have only one edge selected and the Connect RMB command is activated the it was entering in slide mode even without a valid edge to move. That could trick the user.

NOTE: Fixed the Connect RMB command that was entering in slide mode after no connection has been done.