### PR TITLE
Fixed a soft crash caused by selectiong MMB for Flow Connect command

### DIFF
--- a/plugins_src/commands/wpc_flow_connect.erl
+++ b/plugins_src/commands/wpc_flow_connect.erl
@@ -34,7 +34,7 @@ parse([Elem|Rest], NewMenu, Found) ->
     parse(Rest, [Elem|NewMenu], Found).
 
 flow_connect() ->
-    {?__(1,"Flow Connect"),{flow_connect, flow_connect_fun()},
+    {?__(1,"Flow Connect"),flow_connect_fun(),
      {?__(2,"Connect edges with respect to the surrounding geometry"),[],
       ?__(3,"Flow Connect and move edges into place")},[]}.
 


### PR DESCRIPTION
It was noticed that Flow Connect command was causing a soft crash if we select it by using the MMB - which doesn't has any action assigned.

```
Long stack trace:
[{wings_menu,make_entries,
             [[flow_connect,edge],{edge,flow_connect},pretty],
             [{file,"wings_menu.erl"},{line,970}]},
 {wings_menu,wx_popup_menu,6,[{file,"wings_menu.erl"},{line,179}]},
```

NOTE: Fixed a soft crash caused by selectiong MMB for Flow Connect command