### PR TITLE
Fixed wrong topology created by Collapse command in face mode

### DIFF
--- a/src/wings_face_cmd.erl
+++ b/src/wings_face_cmd.erl
@@ -181,7 +181,7 @@ command(put_on, St) ->
 command(clone_on, St) ->
     clone_on(St);
 command(collapse, St) ->
-    {save_state,wings_collapse:collapse(St)};
+    {save_state,collapse(St)};
 command({material,Cmd}, St) ->
     wings_material:command(Cmd, St);
 command({move,Type}, St) ->
@@ -1439,6 +1439,14 @@ clone_on_targets(#st{selmode=Mode}=St) ->
          end,
     RF = fun erlang:'++'/2,
     wings_sel:dfold(MF, RF, [], St).
+
+%%%
+%%% Collapse Faces
+%%%
+
+collapse(St0) ->
+    St = dissolve(St0),
+    wings_collapse:collapse(St).
 
 %%%
 %%% Hide/Unhide Faces


### PR DESCRIPTION
It was noticed that Collapse command in face mode was creating unexpected topology. It's expected to get the new vertices to be created in the center of the face/region.
It works correctly if we dissolve the faces before.
![Face-Dissolve-bug-1](https://user-images.githubusercontent.com/365243/235460714-d1178fe8-87f2-4636-8109-0d9923cadc04.png)

![Face-Dissolve-bug-2](https://user-images.githubusercontent.com/365243/235460968-d206068c-b189-450a-99b8-7e85e64c63f8.png)
_Left is the result for the current code and right is for the proposed fix._

NOTE: Fixed the Collapse command that was creating wrong topology in face mode. Thanks to ptoing.

