### PR TITLE
Fixed the file type in dialog for exporting glTF

### DIFF
--- a/plugins_src/import_export/wpc_gltf.erl
+++ b/plugins_src/import_export/wpc_gltf.erl
@@ -59,15 +59,17 @@ do_export(Ask, Op, _Exporter, _St) when is_atom(Ask) ->
 	       fun(Res) ->
 		       {file,{Op,{glb,Res}}}
 	       end);
-do_export(Attr, _Op, Exporter, _St) when is_list(Attr) ->
+do_export(Attr, _Op, Exporter, #st{file=File}=_St) when is_list(Attr) ->
     set_pref(Attr),
     SubDivs = proplists:get_value(subdivisions, Attr, 0),
     Uvs = proplists:get_bool(include_uvs, Attr),
+    FileName = filename:basename(File,".wings"),
     %% Units = proplists:get_value(units, Attr),
     Ps = [{include_uvs,Uvs},%% {units,Units},
           {tesselation, triangulate},
           {include_hard_edges, true},
-          {subdivisions,SubDivs}|props(proplists:get_value(file_type, Attr))],
+          {subdivisions,SubDivs},
+          {default_filename,FileName}|props(proplists:get_value(file_type, Attr))],
     Exporter(Ps, export_fun(Attr)),
     keep.
 

--- a/plugins_src/import_export/wpc_gltf.erl
+++ b/plugins_src/import_export/wpc_gltf.erl
@@ -67,7 +67,7 @@ do_export(Attr, _Op, Exporter, _St) when is_list(Attr) ->
     Ps = [{include_uvs,Uvs},%% {units,Units},
           {tesselation, triangulate},
           {include_hard_edges, true},
-	  {subdivisions,SubDivs}|props()],
+          {subdivisions,SubDivs}|props(proplists:get_value(file_type, Attr))],
     Exporter(Ps, export_fun(Attr)),
     keep.
 
@@ -83,10 +83,12 @@ dialog(Type) ->
      %% wpa:dialog_template(?MODULE, units), panel,
      wpa:dialog_template(?MODULE, Type, [include_colors, include_normals])].
 
-props() ->
-    [{extensions,
-      [{".glb",  "gltf binary"},
-       {".gltf", "gl Transmission Format"}]}].
+props(Type) ->
+    Ext = case Type of
+              glb -> {".glb",  "gltf binary"};
+              gltf -> {".gltf", "gl Transmission Format"}
+          end,
+    [{extensions, [Ext]}].
 
 set_pref(KeyVals) ->
     wpa:pref_set(?MODULE, KeyVals).


### PR DESCRIPTION
- Fixed the file type in dialog for exporting glTF;
- Initialized the file name to be exported with the project name.

NOTE:
The file type in the file dialog now is in accordance with the glTF type
chosen in the option dialog. Thanks to markie