### PR TITLE
Replaced the ":" from object name which was a problem for .dae exporter

### DIFF
--- a/plugins_src/primitives/wpc_tt.erl
+++ b/plugins_src/primitives/wpc_tt.erl
@@ -256,7 +256,7 @@ trygen(File, Text, Idx, Nsubsteps, Size) ->
         [_|_] ->
             {CX,_CY,CZ} = e3d_vec:average(tuple_to_list(e3d_bv:box(Vs0))),
             Vs = [{X-CX,Y,Z-CZ} || {X,Y,Z} <- Vs0],
-            {new_shape,"text: " ++ Text,Fs,Vs,He};
+            {new_shape,"text_" ++ Text,Fs,Vs,He};
         [] ->
             keep
     end.


### PR DESCRIPTION
The character was introduced in the true-type support review in 2015.

NOTE:
Replaced the character ":" by "_" in text primitive name in order to avoid problems 
for some exporters that no allow that.