### PR TITLE
Suppress warnings for matching with 0.0

### DIFF
--- a/e3d/Makefile
+++ b/e3d/Makefile
@@ -53,7 +53,7 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.beam)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror $(TYPE_FLAGS)
+ERL_COMPILE_FLAGS += +nowarn_match_float_zero -Werror $(TYPE_FLAGS)
 
 # ----------------------------------------------------
 # Targets

--- a/plugins_src/autouv/Makefile
+++ b/plugins_src/autouv/Makefile
@@ -44,7 +44,7 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.beam)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror -pa $(WINGS_INTL) -I $(WINGS_TOP) $(TYPE_FLAGS) +debug_info
+ERL_COMPILE_FLAGS += +nowarn_match_float_zero -Werror -pa $(WINGS_INTL) -I $(WINGS_TOP) $(TYPE_FLAGS) +debug_info
 
 # ----------------------------------------------------
 # Targets

--- a/plugins_src/commands/Makefile
+++ b/plugins_src/commands/Makefile
@@ -70,7 +70,7 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.beam)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -pa $(WINGS_INTL) -Werror -I $(WINGS_TOP) $(TYPE_FLAGS) +debug_info
+ERL_COMPILE_FLAGS += -pa $(WINGS_INTL) +nowarn_match_float_zero -Werror -I $(WINGS_TOP) $(TYPE_FLAGS) +debug_info
 
 # ----------------------------------------------------
 # Targets

--- a/plugins_src/import_export/Makefile
+++ b/plugins_src/import_export/Makefile
@@ -59,7 +59,7 @@ TARGET_FILES= $(MODULES:%=$(EBIN)/%.beam)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror -pa $(WINGS_INTL) \
+ERL_COMPILE_FLAGS += +nowarn_match_float_zero -Werror -pa $(WINGS_INTL) \
   -I $(WINGS_TOP) $(TYPE_FLAGS) +debug_info
 
 # ----------------------------------------------------

--- a/src/Makefile
+++ b/src/Makefile
@@ -147,7 +147,7 @@ APP_TARGET = $(EBIN)/$(APP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror -I ../.. -I../_deps $(TYPE_FLAGS) -pa $(WINGS_INTL)
+ERL_COMPILE_FLAGS += +nowarn_match_float_zero -Werror -I ../.. -I../_deps $(TYPE_FLAGS) -pa $(WINGS_INTL)
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
In OTP 26.1, matching with 0.0 will produce a warning. For the moment, suppress the warning.