### PR TITLE
Fixed the menu selection that was letting garbage

### DIFF
--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -220,6 +220,9 @@ setup_dialog(Parent, Entries, Magnet, ScreenPos, Cache) ->
             end,
             MenuData;
         #{frame := Frame} = MenuData ->
+            Entries0 = maps:get(entries, MenuData),
+            Col = maps:get(colors, MenuData),
+            menu_sel_cleanup(Col, Entries0),
             wxWindow:move(Frame, ScreenPos),
             wxPopupTransientWindow:popup(Frame),
             MenuData
@@ -1103,6 +1106,24 @@ menu_item_desc(Desc, HotKey) ->
 	{win32, _} -> Desc ++ "\t'" ++ HotKey ++ "'";
 	_ -> Desc ++ "\t" ++ HotKey
     end.
+
+menu_sel_cleanup(_, []) -> ok;
+menu_sel_cleanup({BG,FG}=Col, [#menu{type=submenu, object=undefined, wxid=Id}|Menu]) ->
+    Panel = wxWindow:findWindowById(Id),
+    Set = fun() ->
+            setup_colors([Panel|wxWindow:getChildren(Panel)], BG, FG)
+        end,
+    wx:batch(Set),
+    menu_sel_cleanup(Col,Menu);
+menu_sel_cleanup({BG,FG}=Col, [#menu{type=menu, object=Obj}|Menu]) ->
+    Panel = maps:get(panel, Obj),
+    Set = fun() ->
+            setup_colors(Panel, BG, FG)
+        end,
+    wx:batch(Set),
+    menu_sel_cleanup(Col,Menu);
+menu_sel_cleanup(Col, [_|Menu]) ->
+    menu_sel_cleanup(Col,Menu).
 
 %% We want to use the predefined id where they exist (mac) needs for it's
 %% specialized menus but we want our shortcuts hmm.


### PR DESCRIPTION
This issue was introduced by the fix for another menu issue that was crashing Wings3D when closing a window with the context menu active (commit: #[be68730](https://github.com/dgud/wings/commit/be687309ebc10f0bf489aa5c05e179e7eed7e3de))

The fix redraw the entire menu unselected before it be displayed. It was also needed to find for the window of the submenu item because it's not stored in the object property of menudata.
It was reported in this [post](http://www.wings3d.com/forum/showthread.php?tid=3146&pid=17168#pid17168)

NOTE: Fixed the menu selection that was letting garbage. Thanks to sciroccorics