### PR TITLE
Fix triple quote warning

### DIFF
--- a/plugins_src/import_export/wpc_yafaray.erl
+++ b/plugins_src/import_export/wpc_yafaray.erl
@@ -4008,8 +4008,8 @@ export_blend_mat_shader(F, Name, Mat, ExportDir, YafaRay) ->
 
     Blend_Value = proplists:get_value(blend_value, YafaRay, ?DEF_BLEND_VALUE),
 
-    uniprintln(F, "  <material1 sval=\"""w_""\~ts\"/>~n"
-                  "        <material2 sval=\"""w_""\~ts\"/>~n"
+    uniprintln(F, "  <material1 sval=\"w_\~ts\"/>~n"
+                  "        <material2 sval=\"w_\~ts\"/>~n"
                   "        <blend_value fval=\"~.10f\"/>~n",
             [Blend_Mat1,Blend_Mat2,Blend_Value]),
     foldl(fun ({modulator,Ps}=M, N) when is_list(Ps) ->


### PR DESCRIPTION
Without the change, I got this warning (and thus build error):

```
erlc +nowarn_match_float_zero -Werror -pa ../../intl_tools -I ../../..  +debug_info -o../../plugins/import_export wpc_yafaray.erl
compile: warnings being treated as errors
wpc_yafaray.erl:4011:41: adjacent string literals without intervening white space
In OTP-27.0 this will be a triple-quoted string or an error.
Rewrite them as one string, or insert white space
between the strings.
% 4011|     uniprintln(F, "  <material1 sval=\"""w_""\~ts\"/>~n"
%     |                                         ^

wpc_yafaray.erl:4011:45: adjacent string literals without intervening white space
In OTP-27.0 this will be a triple-quoted string or an error.
Rewrite them as one string, or insert white space
between the strings.
% 4011|     uniprintln(F, "  <material1 sval=\"""w_""\~ts\"/>~n"
%     |                                             ^

wpc_yafaray.erl:4012:47: adjacent string literals without intervening white space
In OTP-27.0 this will be a triple-quoted string or an error.
Rewrite them as one string, or insert white space
between the strings.
% 4012|                   "        <material2 sval=\"""w_""\~ts\"/>~n"
%     |                                               ^

wpc_yafaray.erl:4012:51: adjacent string literals without intervening white space
In OTP-27.0 this will be a triple-quoted string or an error.
Rewrite them as one string, or insert white space
between the strings.
% 4012|                   "        <material2 sval=\"""w_""\~ts\"/>~n"
%     |                                                   ^

make[5]: *** [../../plugins/import_export/wpc_yafaray.beam] Error 1
make[4]: *** [opt] Error 2
make[3]: *** [subdirs] Error 2
make[2]: *** [opt] Error 2
make[1]: *** [plugins_src] Error 2
make: *** [opt] Error 2
```

More here: https://www.erlang.org/docs/26/general_info/upcoming_incompatibilities#triple-quoted-strings