### PR TITLE
Fixed the menu location in order to fit on the display it is activated

### DIFF
--- a/src/wings_menu.erl
+++ b/src/wings_menu.erl
@@ -411,7 +411,6 @@ popup_events(MenuData, Magnet, Previous, Ns, Owner) ->
 
 fit_menu_on_display(Frame, {MX,MY} = Pos) ->
     {WW,WH} = wxWindow:getSize(Frame),
-    wxDisplay:getFromWindow(Frame),
     %% When multiple resolution displays are present, there is a situation which
     %% the window being shared partially by two of them - and the window being
     %% scaled up - the Display ID returned is -1. In order to avoid a crash it we


### PR DESCRIPTION
OBS: There are two fix on this PR because the second one was causing conflict if it was separated.

**1**) This issue was added when I remove a old workaround for multiple display
setup and didn't pay attention that it was also making the menu window
to fit on a display. I revert the commit and rewrote it.

It's not perfect for setups where the displays have different resolution.
When the window is placed entirely on a display everything works fine, but
if a window is shared by multiple displays, in a location where
a window is scaled, the correct dimensions can not be safely evaluated
and then we can still get the popup menu cropped. (see images bellow)

![IMG_20231017_163219](https://github.com/dgud/wings/assets/365243/50a4b6b3-aa7f-43fa-8290-a7f4692989cb)

![IMG_20231017_163118](https://github.com/dgud/wings/assets/365243/1f2907fa-f953-46e1-a116-866fb19c0acf)

**2**) This issue was introduced by the fix for another menu issue that was crashing
Wings3D when closing a window with the context menu active (commit: #be68730).
 _* It can be seen in the previous image in which we see two items selected when the menu was shown._

The fix redraw the entire menu unselected before it be displayed. It was also
needed to find for the window of the submenu item because it's not stored in
the object property of menudata.

NOTE: 
- Fixed the popup menu location that can be shown out of screen.
Thanks to Xavier
- Fixed the menu selection that was letting garbage. 
Thanks to sciroccorics