### PR TITLE
Preventing Wings3D hard crash on issue related to Geometry Graph window

### DIFF
--- a/src/wings_geom_win.erl
+++ b/src/wings_geom_win.erl
@@ -566,14 +566,18 @@ handle_event(#wx{event=#wxList{type=Op, itemIndex=Indx, col=Col}},
 
 handle_event(#wx{event=#wxTree{type=command_tree_sel_changed, item=Indx}},
 	     #state{name=Name, tree=Tree} = State) ->
-    {_, Folder} = lists:keyfind(Indx, 1, Tree),
-    Apply = fun(#st{pst=Pst0} = St) ->
-		    {_,Fld} = gb_trees:get(?FOLDERS, Pst0),
-		    Pst = gb_trees:enter(?FOLDERS, {Folder,Fld}, Pst0),
-		    send_client({update_state,St#st{pst=Pst}}),
-		    keep
-	    end,
-    wings_wm:psend(Name, {apply, false, Apply}),
+    case lists:keyfind(Indx, 1, Tree) of
+        {_, Folder} ->
+            Apply = fun(#st{pst=Pst0} = St) ->
+                    {_,Fld} = gb_trees:get(?FOLDERS, Pst0),
+                    Pst = gb_trees:enter(?FOLDERS, {Folder,Fld}, Pst0),
+                    send_client({update_state,St#st{pst=Pst}}),
+                    keep
+                end,
+            wings_wm:psend(Name, {apply, false, Apply});
+        _ ->
+            ignore
+    end,
     {noreply, State};
 
 handle_event(#wx{event=#wxTree{type=command_tree_item_menu, item=Indx, pointDrag=Pos0}},


### PR DESCRIPTION
Fixed a crash in Geometry Graph window when processing the _command_tree_sel_changed_ 
event in a project with multiple folders and objects.  
The origin of the problem could not be found, but the inclusion 
of a validation was able to avoid the hard crash.

This issue was reported by the user @envelupo at Discord and it was 
closing the window during a Snap operation. It was in a setup with 
a couple of folders and objects and as shown in video the Geometry 
Graph starts flicking and then crash: [link Discord](https://discord.com/channels/631099202012708874/1274902097753804892/1312872328232829010)

NOTE:  Preventing Wings3D hard crash on issue related to Geometry Graph 
window update. Thanks to @envelupo