### PR TITLE
Fixed the text location in the info line inside the Geometry window

### DIFF
--- a/plugins_src/commands/wpc_sculpt.erl
+++ b/plugins_src/commands/wpc_sculpt.erl
@@ -861,7 +861,7 @@ help(#sculpt{mag=Mag,rad=Rad,mag_type=MagType,str=Str,mode=Mode}) ->
     {_,H} = wings_wm:win_size(),
     Constraint = constraint_info(),
     LLine = wings_msg:join([?__(10,"Sculpt Mode")++": "++ModeMsg,StatusBar,Constraint]),
-    wings_io:info(0, H-?LINE_HEIGHT-3, LLine),
+    wings_io:info(0, H-?LINE_HEIGHT-4, LLine),
     wings_wm:message(wings_msg:join([Sculpt,Menu,Exit]),
                      wings_msg:join([Radius,Strength])).
 

--- a/src/wings_io.erl
+++ b/src/wings_io.erl
@@ -249,7 +249,7 @@ info(X, Y, Info) ->
 		  gl:recti(X, Y, W, Y + N*?LINE_HEIGHT + 6)
 	  end),
     set_color(wings_pref:get_value(info_color)),
-    wings_text:render(X + 5, Y + ?CHAR_HEIGHT+3, Info).
+    wings_text:render(X + 5, Y + ?CHAR_HEIGHT+2, Info).
 
 info_lines(Info) ->
     info_lines_1(Info, 1).

--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -957,7 +957,7 @@ show_scale(W, H, Scale) ->
     ScaleStr = float_to_list(float(Scale),[{decimals, 4}, compact]),
     StrScale = ?__(1,"Grid Scale: x")++ScaleStr,
     X = W-wings_text:width(StrScale)-10,
-    wings_io:info(X, H-18, StrScale).
+    wings_io:info(X, H-?LINE_HEIGHT-4, StrScale).
 
 show_saved_bb(St) ->
     Key = get_saved_bb_key(St),

--- a/src/wings_tweak.erl
+++ b/src/wings_tweak.erl
@@ -2212,7 +2212,7 @@ modifier({Ctrl,Shift,Alt}) ->
 
 draw_tweak_info_line(Msg) ->
     {_,H} = wings_wm:win_size(),
-    wings_io:info(0, H-?LINE_HEIGHT-3, wings_msg:join([Msg])).
+    wings_io:info(0, H-?LINE_HEIGHT-4, wings_msg:join([Msg])).
 
 %%%
 %%% XYZ Constraints Info line while Tweaking


### PR DESCRIPTION
Fixed the text location in the information line inside the Geometry window which was cutting of the 
text in Linux as well was fixed the misalignment of "Grid Scale" text with the main information text.

The issue was reported by thedæmon in [this post](https://discord.com/channels/631099202012708874/1274902097753804892/1302780415924375624) at Discord.
![image](https://github.com/user-attachments/assets/35000057-574c-40c4-9158-ddfe73820386)

here is the before and after the fix:
![image](https://github.com/user-attachments/assets/07ffed4f-5b5a-4bd6-805c-c3bcbf8c111d)

NOTE: Fixed the text location in the information line inside the Geometry window. Thanks to @thedæmon

