### PR TITLE
Fixed the autosave status for Revert command

### DIFF
--- a/src/wings_file.erl
+++ b/src/wings_file.erl
@@ -704,6 +704,7 @@ confirmed_revert_1(#st{file=File}=St0) ->
     case ?SLOW(wings_ff_wings:import(File, St1)) of
 	#st{}=St2 ->
 	    St = wings_obj:recreate_folder_system(St2),
+        wings_u:caption(St#st{saved=true}),
 	    clean_images(St);
 	{error,_}=Error ->
 	    Error


### PR DESCRIPTION
Fixed the autosave status for Revert command after a Revert operation has been used. 
It was reported by **jczd** in this [post](https://discord.com/channels/631099202012708874/1274902097753804892/1318899623829704775) at Discord

NOTE: Fixed the autosave status which was kept "unsaved" after a Revert command be used. Thanks to @jczd