### PR TITLE
Added the MMB option to the Connect command

### DIFF
--- a/src/wings_drag.erl
+++ b/src/wings_drag.erl
@@ -1399,7 +1399,7 @@ trim([[_|_]=H|T]) ->
 trim(S) -> S.
 
 normalize(Move, #drag{mode_fun=ModeFun,mode_data=ModeData,
-		      st=#st{shapes=Shs0,sel=Sel0}=St}) ->
+            st=#st{shapes=Shs0,sel=Sel0}=St}) ->
     ModeFun(done, ModeData),
     gl:disable(gl_rescale_normal()),
     {Shs,Sel} = wings_dl:map(fun(D, Sh) ->
@@ -1410,7 +1410,7 @@ normalize(Move, #drag{mode_fun=ModeFun,mode_data=ModeData,
     end,
     St#st{shapes=Shs,sel=Sel}.
 
-normalize_fun(#dlo{drag=none}=D, _Move, Shs) -> {D,Shs};
+normalize_fun(#dlo{drag=none}=D, _Move, ShsSel) -> {D,ShsSel};
 normalize_fun(#dlo{drag={matrix,_,_,_},transparent=#we{id=Id}=We,
 		   proxy_data=PD}=D0, _Move, {Shs0,Sel}) when ?IS_LIGHT(We) ->
     Shs = gb_trees:update(Id, We, Shs0),

--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -195,13 +195,9 @@ connect(Es0, We0) ->
 
 connect_multiple(St0) ->
 	St = wings_sel:map_update_sel(fun connect_multiple_1/2, St0),
-	ConFun0 = fun([N], _)->
-				if N < 1.0 -> 1;
-				true -> trunc(N)
-				end
-			end,
+	ConFun0 = fun([N|_], _)-> N end,
 	DF = fun(_) -> adjust_fun(ConFun0) end,
-	Units = [absolute_diameter],
+	Units = [{count,{1,infinity}}],
 	Flags = [{initial,[1]}],
 	wings_drag:general(DF, Units, Flags, St).
 

--- a/src/wings_edge_cmd.erl
+++ b/src/wings_edge_cmd.erl
@@ -42,7 +42,7 @@ menu(X, Y, St) ->
 	    cut_line(St),
 	    {?__(6,"Connect"),connect(),
 	     	{?__(7,"Create a new edge by connecting midpoints of selected edges"),
-			 ?__(26,"Create multiple parallel edges by connecting selected edges."),
+			 ?__(26,"Create multiple parallel edges by connecting selected edges"),
 		 	 ?__(25,"Create a new edge and slides it along neighbor edges")},[]},
 	    {?__(8,"Bevel"),bevel,
 	     ?__(9,"Round off selected edges")},
@@ -230,7 +230,6 @@ connect_multiple_1(Es0, We) ->
 	Es2 = remove_nonconnectable(Es1, Es0, We, []),
 	Es = gb_sets:from_list(Es2),
 	{We#we{temp={0,Es,We}},Es}.
-
 
 connect_slide(St0) ->
     St = wings_sel:map_update_sel(fun connect/2, St0),


### PR DESCRIPTION
I spent two days traying to add an MMB option to the Connect command that could
allow us to connect edges multiple times by dragging the mouse on screen as we
use to do other adjustments.

The way the dragging code works currently doesn't updates correctly the model after
we finish the command. So, I changed it a little and it's working gracefully now.
It was required to check for selection changes as well as force  _dlist_ to be invalidated.

I hope you can approve this change or suggest a better way to achieve the result. This 
kind of dynamic update could be used in other commands we can add further.

NOTE: Added the MMB option to the Connect command, allowing us to dynamically
increase the amount of cut;

![connect-multiple2](https://github.com/user-attachments/assets/61397796-5bb3-4e3a-a3f4-7ee01254a79b)
