### PR TITLE
Added no extension filter for file chooser

### DIFF
--- a/src/wings_job.erl
+++ b/src/wings_job.erl
@@ -32,7 +32,7 @@ browse_props() ->
 	    case os:type() of
 		{win32,_} -> 
 		    {extensions,[{".exe","Windows Executable"}]};
-		_-> {extensions,[]}
+		_-> {extensions,[{"","Executable"}]}
 	    end]}.
 
 %% Render formats that may be handled


### PR DESCRIPTION
Made a fix so the file dialog uses "*" as the filter in non-Windows
environments to find binaries. The "all files" filter uses "*.*" which
the file dialog won't find binaries.