### PR TITLE
Added RMB option to the Projection Camera in the UV Segmentation window

### DIFF
--- a/plugins_src/autouv/auv_mapping.erl
+++ b/plugins_src/autouv/auv_mapping.erl
@@ -87,7 +87,7 @@ map_chart_1(Type, Chart, Loop, Options, We) ->
     end.
 
 map_chart_2(project, C, _, _, We) ->    projectFromChartNormal(C, We);
-map_chart_2(camera, C, _, Dir, We) ->   projectFromCamera(C, Dir, We);
+map_chart_2({camera,_}, C, _, Dir, We) ->   projectFromCamera(C, Dir, We);
 map_chart_2(lsqcm, C, Loop, Pinned, We) ->
     case get(auv_use_erlang_impl) == true
         orelse erlang:system_info(wordsize) =:= 4 of

--- a/plugins_src/autouv/auv_util.erl
+++ b/plugins_src/autouv/auv_util.erl
@@ -17,7 +17,7 @@
 -export([moveAndScale/5]).
 -export([outer_edges/2,outer_edges/3]).
 -export([number/1,number/2]).
--export([mark_segments/4,make_mat/1,seg_materials/0]).
+-export([mark_segments/4,make_mat/1,seg_materials/0, uv_mode/1]).
 
 -include_lib("wings/src/wings.hrl").
 -include("auv.hrl").
@@ -183,3 +183,6 @@ reuse_materials_1(Orig={_, Outer, Fs0}, [Keep = {_, Chart,Fs1}|Rest],
     end;
 reuse_materials_1({_, _, Combined}, [], Size, _We, Acc) ->
     {lists:reverse(Acc), Combined, Size}.
+
+uv_mode({camera,Mode}) -> Mode;
+uv_mode(_) -> arrange.

--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -25,7 +25,7 @@
 -import(lists, [sort/1,keysort/2,map/2,foldl/3,reverse/1,keysearch/3]).
 
 %% Exports to auv_seg_ui.
--export([init_show_maps/4]).
+-export([init_show_maps/4,init_show_maps/5]).
 %% Exports to auv_texture.
 -export([material_faces/1,get_textureset_info/1,remap_uv_tile/1]).
 
@@ -258,8 +258,11 @@ do_edit(MatName0, Mode, We0, #st{mat=Materials,shapes=Shs0}=GeomSt0) ->
     camera_reset(),
     new_geom_state(GeomSt, AuvSt).
 
-init_show_maps(Charts0, Fs, #we{name=WeName,id=Id}, GeomSt0) ->
-    Charts1 = auv_placement:place_areas(Charts0),
+init_show_maps(Charts0, Fs, We, GeomSt0) ->
+    init_show_maps(preserve, Charts0, Fs, We, GeomSt0).
+
+init_show_maps(UVMode, Charts0, Fs, #we{name=WeName,id=Id}, GeomSt0) ->
+    Charts1 = auv_placement:place_areas(UVMode,Charts0),
     Charts  = gb_trees:from_orddict(keysort(1, Charts1)),
     MatName0 = list_to_atom(WeName++"_auv"),
     {GeomSt1,MatName} = 


### PR DESCRIPTION
This can be particularly useful for text-based texturing.

Note: The RMB option helps preserve the layout of UV islands as displayed in the viewer. Thanks to envelupo for the suggestion.