### PR TITLE
Added an option to apply ambient occlusion (AO) blending with vertex colors

### DIFF
--- a/src/wings_color.erl
+++ b/src/wings_color.erl
@@ -18,7 +18,7 @@
 	 rgba_to_rgb/1, rgb3bv/1, rgb4bv/1, rgb3fv/1, rgb4fv/1,
          srgb_to_linear/1,
 	 hsb_to_rgb/3, lab_to_rgb/3, cmyk_to_rgb/4,
-	 def_palette/0
+	 def_palette/0, blend/2
 	]).
 
 -include("wings.hrl").
@@ -487,3 +487,33 @@ get_palette(_, _) -> [].
 %%     Sto = gb_trees:update(val, V, Sto6),
 %%     {store,Sto};
 %% eyepicker_update(_, _) -> void.
+
+blend({R0,G0,B0}, ColorToBlend) ->
+    {R,G,B,_} = blend_0({R0,G0,B0,1}, tuple_to_list(ColorToBlend)),
+    {R,G,B};
+blend(Color, ColorToBlend) ->
+    blend_0(Color, tuple_to_list(ColorToBlend)).
+
+blend_0({R,G,B,A}, [Gr0,Gr0,Gr0|_]) when is_integer(R) ->
+    {Gr,_,_} = rgb3bv({Gr0,Gr0,Gr0}),
+    Factor = Gr / 255,
+    {round(R * Factor),
+     round(G * Factor),
+     round(B * Factor),
+     A};
+blend_0({R,G,B,A}, [Rb0,Gb0,Bb0|_]) when is_integer(R) ->
+    {Rb,Gb,Bb} = rgb3bv({Rb0,Gb0,Bb0}),
+    {(R + Rb) div 2,
+        (G + Gb) div 2,
+        (B + Bb) div 2,
+        A};
+blend_0({R,G,B,A}, [Gr,Gr,Gr|_]) ->
+    {R * Gr,
+     G * Gr,
+     B * Gr,
+     A};
+blend_0({R,G,B,A}, [Rb,Gb,Bb|_]) ->
+    {(R + Rb) / 2,
+     (G + Gb) / 2,
+     (B + Bb) / 2,
+     A}.

--- a/src/wings_va.erl
+++ b/src/wings_va.erl
@@ -17,7 +17,7 @@
 	 face_mixed_attrs/2,
 	 all/2,edge_attrs/3,edge_attrs/4,set_edge_attrs/4,set_both_edge_attrs/4,
 	 set_edge_attrs/2,set_edge_uvs/2,set_edge_colors/2,del_edge_attrs/2,
-	 set_edge_color/4,
+	 set_edge_color/4,blend_edge_color/4,
 	 vtx_attrs/2,vtx_attrs/3,attr/2,new_attr/2,average_attrs/1,average_attrs/2,
 	 set_vtx_face_uvs/4,
 	 remove/2,remove/3,renumber/2,merge/2,gc/1,any_update/2]).
@@ -303,6 +303,13 @@ set_edge_colors(List, #we{lv=Lva0,rv=Rva0}=We) ->
 set_edge_color(Edge, LeftCol, RightCol, #we{lv=Lva0,rv=Rva0}=We) ->
     Lva = set_color(Edge, LeftCol, Lva0),
     Rva = set_color(Edge, RightCol, Rva0),
+    We#we{lv=Lva,rv=Rva}.
+
+%% mix_edge_color(Edge, LeftColor, RightColor, We0) -> We
+%%  Blend the current vertex colors and the new color to the edge.
+blend_edge_color(Edge, LeftCol, RightCol, #we{lv=Lva0,rv=Rva0}=We) ->
+    Lva = blend_color(Edge, LeftCol, Lva0),
+    Rva = blend_color(Edge, RightCol, Rva0),
     We#we{lv=Lva,rv=Rva}.
 
 %% del_edge_attrs(Edge, We0) -> We.
@@ -802,6 +809,13 @@ set_uv(Edge, UV, Tab) ->
 	       [Color|_] -> [Color|UV]
 	   end,
     aset(Edge, Attr, Tab).
+
+blend_color(Edge, Color, Tab) ->
+    case aget(Edge, Tab) of
+        none -> aset(Edge, [Color|none], Tab);
+        [Color|_] -> Tab;
+        [OldColor|UV] -> aset(Edge, [wings_color:blend(OldColor,Color)|UV], Tab)
+    end.
 
 mix(_, none, _) -> none;
 mix(_, [_|_], none) -> none;

--- a/src/wings_va.erl
+++ b/src/wings_va.erl
@@ -305,7 +305,7 @@ set_edge_color(Edge, LeftCol, RightCol, #we{lv=Lva0,rv=Rva0}=We) ->
     Rva = set_color(Edge, RightCol, Rva0),
     We#we{lv=Lva,rv=Rva}.
 
-%% mix_edge_color(Edge, LeftColor, RightColor, We0) -> We
+%% blend_edge_color(Edge, LeftColor, RightColor, We0) -> We
 %%  Blend the current vertex colors and the new color to the edge.
 blend_edge_color(Edge, LeftCol, RightCol, #we{lv=Lva0,rv=Rva0}=We) ->
     Lva = blend_color(Edge, LeftCol, Lva0),


### PR DESCRIPTION
To enable a different action via the application menu, the CTRL modifier key was used to trigger a secondary option for the AO command. This is a useful feature for those who paint vertex objects for use in games.

NOTE:
Added an option to apply AO blending with vertex colors. Thanks to boggers and DevEarley for the suggestion