### PR TITLE
AutoUV Segmenting was rewritten the AutoUV state

### DIFF
--- a/plugins_src/autouv/auv_seg_ui.erl
+++ b/plugins_src/autouv/auv_seg_ui.erl
@@ -205,6 +205,11 @@ seg_event_5(Ev, #seg{st=St0}=Ss) ->
 seg_event_6({new_state,St}, Ss) ->
     get_seg_event(Ss#seg{st=St});
 
+seg_event_6({new_orig_state,{Id,#st{shapes=Shp1,mat=TMat}}}, #seg{orig_st=#st{shapes=Shp0}=St}=Ss) ->
+    We = gb_trees:get(Id,Shp1),
+    Shp = gb_trees:enter(Id,We,Shp0),
+    get_seg_event(Ss#seg{orig_st=St#st{shapes=Shp,mat=TMat}});
+
 seg_event_6({action,{view,Cmd}}, #seg{st=St0}=Ss) ->
     case Cmd of
     aim -> 

--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -294,7 +294,7 @@ init_show_maps(Charts0, Fs, #we{name=WeName,id=Id}, GeomSt0) ->
 	    Pos = wxWindow:clientToScreen(SegWin,X0,Y0),
 	    Win = create_window({edit,Fs}, EditWin, Id, GeomSt),
 	    wxWindow:move(Win,Pos),
-	    update_all_seg_ui(SegWin, Id, GeomSt),
+	    update_all_seg_ui(wings_wm:wx2win(SegWin), Id, GeomSt),
 	    wings_wm:send(geom, {new_state,GeomSt})
     end,
     GeomSt.


### PR DESCRIPTION
When a user opened multiple AutoUV Segmenting windows, each window kept its state (#st{}) frozen at the moment it was created. After completing the segmentation process in one window and activating the AutoUV Editor, if the user switched to another segmenting window, the Geometry window would show that the previously segmented object had lost its segmentation.

Note:
- Fixed an issue with multiple AutoUV Segmenting window erasing the previous segmentation. Thanks to Arclite.