### PR TITLE
Added Pick and RMB options to Flatten command in AutoUV editor

### DIFF
--- a/plugins_src/autouv/wpc_autouv.erl
+++ b/plugins_src/autouv/wpc_autouv.erl
@@ -1479,7 +1479,7 @@ repeatable({tighten,_}, Mode) ->
 repeatable(delete, Mode) -> Mode == body;
 repeatable(hide, Mode) -> Mode == body;
 repeatable(flatten, Mode) -> Mode == edge;
-repeatable({flatten_}, Mode) -> Mode == vertex;
+repeatable({flatten, _}, Mode) -> Mode == vertex;
 repeatable(stitch, Mode) ->  Mode == edge;
 repeatable(cut_edges, Mode) -> Mode == edge;
 repeatable(_Cmd,_Mode) ->


### PR DESCRIPTION
The Pick option allows aligning vertices along non-standard axes (X, Y). The RMB option added to X and Y lets us use a vertex as target instead of their average, as it currently works.

NOTE:
- Added Pick and RMB options to Flatten command in AutoUV editor. Thanks to Valghan