### PR TITLE
Fixed an issue related to Wings3D not saving objects' status

### DIFF
--- a/src/wings_geom_win.erl
+++ b/src/wings_geom_win.erl
@@ -560,7 +560,10 @@ handle_event(#wx{event=#wxList{type=Op, itemIndex=Indx, col=Col}},
 	     #state{name=Name, shown=Shown} = State) ->
     {shape, Id} = get_id(Indx, Shown),
     Action = col_name(Col),
-    Apply = fun(St) -> Action(Id, Op, St), keep end,
+    Apply = fun(St) ->
+                Action(Id, Op, St),
+                wings_wm:psend(geom,need_save)
+            end,
     wings_wm:psend(Name, {apply, false, Apply}),
     {noreply, State};
 


### PR DESCRIPTION
It was noticed that changes to visibility, lock, wire, and selection in the Geometry Graph window were not being stored when the file had already been saved. To fix this, these actions now mark the file as needing to be saved.

Note:
Fixed some objects' properties (like visibility) not been saved. Thanks to ozylot