### PR TITLE
Fixed toolbar background theme not being updated

### DIFF
--- a/src/wings_toolbar.erl
+++ b/src/wings_toolbar.erl
@@ -80,6 +80,8 @@ button_sh_filter(_, _) -> false.
 init(Frame, Icons) ->
     wxSystemOptions:setOption("msw.remap", 2),
     TB = wxFrame:createToolBar(Frame),
+    Col = wings_color:rgb4bv(wings_pref:get_value(menu_color)),
+    wxFrame:setBackgroundColour(TB, Col),
     Bs = [make_bitmap(B, Icons) || B <- buttons()],
     Tools = case wings_pref:get_value(extended_toolbar) of
 		true -> Bs;


### PR DESCRIPTION
Most elements in Wings3D can be color customized, and usually the OS uses the menu's background color for elements such as toolbars, which wxWidgets was not doing. So, I set that in the code. Unfortunately, wxErlang does not expose a function to customize normal and checked images, causing buttons to stay backlit when focused.

NOTE: Fixed the toolbar background theme. Thanks AbyssObserver.