### PR TITLE
Fixed OBJ import crashing on IEEE754 special values (nan/inf)

### DIFF
--- a/e3d/e3d_bzw.erl
+++ b/e3d/e3d_bzw.erl
@@ -302,7 +302,7 @@ str2float(S) -> str2float_1(S).
 
 str2float_1(S) ->
     try
-	list_to_float(S)
+	wings_util:string_to_float(S)
     catch
 	error:badarg ->
 	    str2float_2(S, [])
@@ -314,7 +314,7 @@ str2float_2([H|T], Acc) when H == $e; H == $E ->
 	       (D) when $0 =< D, D =< $9 -> ok
 	    end, Acc),
     NumStr = reverse(Acc, ".0e") ++ T,
-    list_to_float(NumStr);
+    wings_util:string_to_float(NumStr);
 str2float_2([H|T], Acc) ->
     str2float_2(T, [H|Acc]);
 str2float_2([], Acc) ->

--- a/e3d/e3d_obj.erl
+++ b/e3d/e3d_obj.erl
@@ -381,7 +381,7 @@ str2float(S) -> str2float_1(S).
 
 str2float_1(S) ->
     try
-	list_to_float(S)
+	wings_util:string_to_float(S)
     catch
 	error:badarg ->
 	    str2float_2(S, [])
@@ -393,7 +393,7 @@ str2float_2([H|T], Acc) when H == $e; H == $E ->
 	       (D) when $0 =< D, D =< $9 -> ok
 	    end, Acc),
     NumStr = reverse(Acc, ".0e") ++ T,
-    list_to_float(NumStr);
+    wings_util:string_to_float(NumStr);
 str2float_2([H|T], Acc) ->
     str2float_2(T, [H|Acc]);
 str2float_2([], Acc) ->

--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -231,10 +231,15 @@ nonzero(Value) ->
     true -> Value
     end.
 
-string_to_float("NaN") -> 0.0;
 string_to_float(Str) ->
-    try list_to_float(Str)
-    catch _:_ -> make_float2(Str)
+    case string:to_lower(Str) of
+        "nan" -> 0.0;
+        "inf" -> 1.0e16;
+        "-inf" -> 1.0e-16;
+        _ ->
+            try list_to_float(Str)
+            catch _:_ -> make_float2(Str)
+            end
     end.
 
 make_float2(Str) ->

--- a/src/wings_util.erl
+++ b/src/wings_util.erl
@@ -232,14 +232,14 @@ nonzero(Value) ->
     end.
 
 string_to_float(Str) ->
-    case string:to_lower(Str) of
-        "nan" -> 0.0;
-        "inf" -> 1.0e16;
-        "-inf" -> 1.0e-16;
-        _ ->
-            try list_to_float(Str)
-            catch _:_ -> make_float2(Str)
-            end
+    try list_to_float(Str)
+    catch _:_ ->
+        case string:to_lower(Str) of
+            "nan" -> 0.0;
+            "inf" -> 1.0e16;
+            "-inf" -> -1.0e16;
+            _ -> make_float2(Str)
+        end
     end.
 
 make_float2(Str) ->


### PR DESCRIPTION
It was reported at SourceForge that Wings3D was crashing when vertex coordinates were exported with nan/inf/1e999 values.
I took a look at and I found we already a utility wings_util:string_to_float/1 that handle it partially. So, I added the 'inf' handle option and then I changed the e3d_obj and e3d_bzw to call it instead of use the list_to_float/1 directly.

In order to set a inf/-inf value on import I used as reference the lower value I found in use in wings_face (1.0e-16).

ref.: https://sourceforge.net/p/wings/bugs/252/

Note: Fixed the obj and bzw importers to handle nan/inf values. Thanks Dr. Mohammadreza Ashouri