### PR TITLE
Add X-Ray (Model Transparency) in View Mode

### DIFF
--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -156,9 +156,8 @@ render_objects(Mode, PM, MM, UseSceneLights) ->
     case IsXray of
         true ->
             gl:enable(?GL_BLEND),
-            %% Use CONSTANT_COLOR to tint the geometry, and ONE_MINUS_CONSTANT_ALPHA for opacity
+            %% CONSTANT_COLOR to tint the geometry, and ONE_MINUS_CONSTANT_ALPHA for opacity
             gl:blendFunc(?GL_CONSTANT_COLOR, ?GL_ONE_MINUS_CONSTANT_ALPHA),
-            %% Art of Illusion's signature soft periwinkle blue (Red, Green, Blue, Alpha)
             gl:blendColor(0.55, 0.60, 0.95, 0.40), 
             gl:depthMask(?GL_FALSE);
         _ -> ok

--- a/src/wings_render.erl
+++ b/src/wings_render.erl
@@ -59,9 +59,10 @@ render(#st{selmode=Mode}=St) ->
     user_clipping_planes(on),
     RS = render_objects(Mode, PM, MM, SceneLights),
     user_clipping_planes(off),
-    call_post_hook(St),
     ground_and_axes(View, PM,MM, RS),
     show_camera_image_plane(),
+    wings_view:load_matrices(true),
+    call_post_hook(St),
     gl:popAttrib(),
     wings_develop:gl_error_check("Rendering scene").
 
@@ -150,21 +151,36 @@ render_objects(Mode, PM, MM, UseSceneLights) ->
             view_from_world => MM},
     RS1 = render_lights(Lights, Mode, PM, RS0),
     {SL, RS2} = setup_scene_lights(UseSceneLights, Lights, RS1),
+
+    IsXray = wings_wm:get_prop(xray),
+    case IsXray of
+        true ->
+            gl:enable(?GL_BLEND),
+            %% Use CONSTANT_COLOR to tint the geometry, and ONE_MINUS_CONSTANT_ALPHA for opacity
+            gl:blendFunc(?GL_CONSTANT_COLOR, ?GL_ONE_MINUS_CONSTANT_ALPHA),
+            %% Art of Illusion's signature soft periwinkle blue (Red, Green, Blue, Alpha)
+            gl:blendColor(0.55, 0.60, 0.95, 0.40), 
+            gl:depthMask(?GL_FALSE);
+        _ -> ok
+    end,
+
     case wings_wm:get_prop(workmode) of
-	false ->
+    false ->
             RS10 = case UseSceneLights of
                        true -> render_smooth_objects(Open, Closed, ambient, RS2); %% amb pass
                        false -> RS2
                    end,
             RS21 = render_smooth_objects(Open, Closed, SL, RS10),
+            IsXray =:= true andalso (begin gl:disable(?GL_BLEND), gl:depthMask(?GL_TRUE) end),
             RS22 = render_wire(NonLights, Mode, true, RS21),
             render_sel_highlight(NonLights, Mode, true, PM, RS22);
-	true ->
+    true ->
             RS10 = case UseSceneLights of
                        true -> render_work_objects(Open, Closed, ambient, RS2); %% amb pass
                        false -> RS2
                   end,
             RS21 = render_work_objects(Open, Closed, SL, RS10),
+            IsXray =:= true andalso (begin gl:disable(?GL_BLEND), gl:depthMask(?GL_TRUE) end),
             RS22 = render_wire(NonLights, Mode, false, RS21),
             render_sel_highlight(NonLights, Mode, false, PM, RS22)
     end.

--- a/src/wings_view.erl
+++ b/src/wings_view.erl
@@ -63,6 +63,7 @@ menu() ->
 	   crossmark(filter_texture)}]}},
      separator,
      {?__(7,"Wireframe"),wireframe,?__(8,"Display selected objects as a wireframe (same for all objects if nothing is selected)")},
+     {?__(99,"X-Ray Mode"),xray,?__(100,"Toggle X-Ray transparent rendering mode"),crossmark(xray)},
      {?__(9,"Shade"),shade,?__(10,"Display selected objects as shaded (same for all objects if nothing is selected)")},
      {?__(11,"Toggle Wireframe"),toggle_wireframe,
       ?__(12,"Toggle display mode for selected objects (same for all objects if nothing is selected)")},
@@ -812,7 +813,8 @@ initial_properties() ->
      {current_view,default_view()},
      {allow_rotation,true},
      {show_info_text,true},
-     {show_wire_backfaces,false}
+     {show_wire_backfaces,false},
+     {xray,false}
     ].
 
 delete_all(St) -> St#st{views={0,{}}}.


### PR DESCRIPTION
this pull request introduces a togglable "X-Ray Mode" to the View menu. it allows for soft, semi-transparent rendering of the mesh.

changes:

- added xray toggle to the view menu and initial properties in wings_view.erl.

- updated render_objects/4 in wings_render.erl to apply gl:blendFunc and gl:blendColor when the xray property is true, bypassing the depth mask for a soft transparency effect.